### PR TITLE
fix(recent-ai): query audio_descriptions instead of AICaptionRequests

### DIFF
--- a/src/services/audioDescriptions.service.ts
+++ b/src/services/audioDescriptions.service.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { AUDIO_DIRECTORY, CURRENT_DATABASE } from '../config';
+import { AI_USER_ID, AUDIO_DIRECTORY, CURRENT_DATABASE } from '../config';
 import { NewAiDescriptionDto } from '../dtos/audioDescriptions.dto';
 import { HttpException } from '../exceptions/HttpException';
 import { IAudioDescription } from '../models/mongodb/AudioDescriptions.mongo';
@@ -687,25 +687,21 @@ class AudioDescriptionsService {
       const perPage = 5;
       const skipCount = (page - 1) * perPage;
       const pipeline: any[] = [
-        { $match: { status: 'completed' } },
+        {
+          $match: {
+            user: new ObjectId(AI_USER_ID),
+            status: 'published',
+          },
+        },
         {
           $lookup: {
             from: 'videos',
-            localField: 'youtube_id',
-            foreignField: 'youtube_id',
+            localField: 'video',
+            foreignField: '_id',
             as: 'video',
           },
         },
         { $unwind: '$video' },
-        {
-          $group: {
-            _id: '$_id',
-            status: { $first: '$status' },
-            video: { $first: '$video' },
-            requestCreatedAt: { $first: '$created_at' },
-            requestCompletedAt: { $first: '$completed_at' },
-          },
-        },
         {
           $project: {
             _id: 1,
@@ -714,11 +710,10 @@ class AudioDescriptionsService {
             youtube_id: '$video.youtube_id',
             video_name: '$video.title',
             video_length: '$video.duration',
-            createdAt: '$requestCompletedAt',
-            updatedAt: '$video.updated_at',
+            updated_at: 1,
           },
         },
-        { $sort: { updatedAt: -1, _id: -1 } },
+        { $sort: { updated_at: -1, _id: -1 } },
         {
           $facet: {
             videos: [{ $skip: skipCount }, { $limit: perPage }],
@@ -732,7 +727,7 @@ class AudioDescriptionsService {
           },
         },
       ];
-      const result = await MongoAICaptionRequestModel.aggregate(pipeline).exec();
+      const result = await MongoAudio_Descriptions_Model.aggregate(pipeline);
       return {
         result: result[0]?.videos || [],
         totalVideos: result[0]?.total || 0,


### PR DESCRIPTION
## Summary

The `/api/audio-descriptions/get-All-AI-descriptions` endpoint feeds the **RECENT AI DESCRIPTIONS** section of the `/wishlist` page. Previously it aggregated `AICaptionRequests` — the user-request lifecycle, status `pending | completed`. This had two problems:

1. **Wrong semantics.** Once a request was marked `completed`, it stayed on the list even after the AI-generated audio_description was unpublished or removed. The section is titled "AI **descriptions**", so it should reflect the actual AD state, not the request state. (Confirmed with manager.)
2. **Silently broken sort.** The aggregation referenced `$created_at` / `$completed_at` on the AICaptionRequest documents, but `AICaptionRequests.mongo.ts` uses Mongoose `timestamps: true`, which auto-creates camelCase `createdAt` / `updatedAt`. The snake-case versions don't exist, so the `$first` calls returned `undefined`, and the final sort silently fell back to `video.updated_at` — i.e., sorted by unrelated video-metadata changes.

This PR rewrites the aggregation to query `audio_descriptions` directly.

## Change

Single file: `src/services/audioDescriptions.service.ts`, function `getAllAIDescriptions`.

- New data source: `MongoAudio_Descriptions_Model`.
- `$match`: `{ user: new ObjectId(AI_USER_ID), status: 'published' }`.
  - `AI_USER_ID` imported from `../config` (already used elsewhere, e.g. `services/users.service.ts`).
  - `'published'` is the `audio_descriptions` equivalent of "AI is done and the description is available for users" — same value `publishAudioDescription` / `unpublishAudioDescription` already set.
- `$lookup` joins by `audio_description.video` (ObjectId) → `videos._id`.
- The redundant `$group` stage was removed — each `audio_description` is already one row.
- `$sort`: `{ updated_at: -1, _id: -1 }`. The schema's existing `pre('updateOne')` hook at `AudioDescriptions.mongo.ts:107` keeps `updated_at` fresh on every update, so unpublish / republish actions reorder the list immediately.
- Response shape (`{ result, totalVideos }`) and pagination behavior unchanged — no frontend coupling.

12 insertions, 17 deletions (the old `$group` stage and the broken-field projection drop out).

## Test plan

1. Sign in to the app, open `/wishlist`, look at the **RECENT AI DESCRIPTIONS** carousel.
2. DevTools → Network → `/get-All-AI-descriptions?pageNumber=1`. The response `result[]` should:
   - Only contain items where `status === 'published'`.
   - Have `updated_at` as a `Number` (YYYYMMDDHHMMSS), decreasing monotonically across the array.
3. Unpublish one of the visible AI-generated AD entries via the editor. Refresh `/wishlist`. The corresponding video should drop off the AI section (vs. before, when it would have stayed because the request was still `completed`).
4. Pagination: click `>` / `<` arrows. `pageNumber` query param should change, response should reflect the new page, total page count unchanged from before.

## Notes

- The `MongoAICaptionRequestModel` import is no longer used by this function, but is still imported in the file for other consumers — leaving it.
- Endpoint path stays `/api/audio-descriptions/get-All-AI-descriptions` to avoid a coupled frontend rename.
