### PR TITLE
fix(auth): return 401 instead of 500 for unauthenticated requests

### DIFF
--- a/src/controllers/audioClips.controller.ts
+++ b/src/controllers/audioClips.controller.ts
@@ -4,6 +4,7 @@ import { AddNewAudioClipDto, UpdateAudioClipDescriptionDto, UpdateAudioClipStart
 import AudioClipsService from '../services/audioClips.service';
 import { IUser } from '../models/mongodb/User.mongo';
 import { MongoAudioClipsModel } from '../models/mongodb/init-models.mongo';
+import { AuthenticationError } from '../utils/customErrors';
 
 export class AudioClipsController {
   public audioClipsService = new AudioClipsService();
@@ -132,7 +133,7 @@ export class AudioClipsController {
       const userData = req.user as unknown as IUser;
       const videoId = req.query.youtubeVideoId;
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const deletedAudioClip = await this.audioClipsService.deleteAudioClip(clipId, userData._id, <string>videoId);
       res.status(200).json(deletedAudioClip);
@@ -147,7 +148,7 @@ export class AudioClipsController {
       const userData = req.user as unknown as IUser;
       const videoId = req.body.youtubeVideoId;
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const restoredClip = await this.audioClipsService.undoDeletedAudioClip(userData._id, videoId);
       if (restoredClip) {

--- a/src/controllers/audioDescriptions.controller.ts
+++ b/src/controllers/audioDescriptions.controller.ts
@@ -6,6 +6,7 @@ import { logger } from '../utils/logger';
 import { IUser } from '../models/mongodb/User.mongo';
 import sendEmail from '../utils/emailService';
 import GpuUtilsService from '../services/gpu_utils.service';
+import { AuthenticationError } from '../utils/customErrors';
 
 class AudioDescripionsController {
   public audioDescriptionsService = new AudioDescriptionsService();
@@ -145,7 +146,7 @@ class AudioDescripionsController {
       const paginate = req.query.paginate !== 'false';
 
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
 
       const audioDescription = await this.audioDescriptionsService.getMyDescriptions(userData._id, <string>pageNumber, paginate);
@@ -162,7 +163,7 @@ class AudioDescripionsController {
       const pageNumber = req.query.page;
 
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
 
       const audioDescription = await this.audioDescriptionsService.getMyDraftDescriptions(userData._id, <string>pageNumber);
@@ -179,7 +180,7 @@ class AudioDescripionsController {
       const pageNumber = req.query.pageNumber;
 
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
 
       const audioDescription = await this.audioDescriptionsService.getAllAIDescriptions(userData._id, <string>pageNumber);

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -12,6 +12,7 @@ import { getYouTubeVideoStatus } from '../utils/util';
 import { deepCopyAudioClip, repairMissingTtsAudio } from '../utils/audioClips.util';
 import { deepCopyAudioDescriptionWithoutNewClips, findExistingCollaborativeDraft, updateAutoClips, updateContributions } from '../utils/audiodescriptions.util';
 import { PipelineFailureDto } from '../dtos/pipelineFailure.dto';
+import { AuthenticationError } from '../utils/customErrors';
 
 class UsersController {
   public userService = new userService();
@@ -353,7 +354,7 @@ class UsersController {
       const pageNumber = req.query.page;
       const paginate = req.query.paginate !== 'false';
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const user = await MongoUsersModel.findById(userData._id);
       if (!user) {
@@ -400,7 +401,7 @@ class UsersController {
       const youtubeId = req.body.youtube_id;
       const invalidate_cache = req.body.invalidate_cache;
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const user = await MongoUsersModel.findById(userData._id);
       if (!user) {
@@ -420,7 +421,7 @@ class UsersController {
       const pageNumber = req.query.page;
       const paginate = req.query.paginate !== 'false';
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const user = await MongoUsersModel.findById(userData._id);
       if (!user) {

--- a/src/controllers/wishlist.controller.ts
+++ b/src/controllers/wishlist.controller.ts
@@ -3,6 +3,7 @@ import WishListService from '../services/wishlist.service';
 import { WishListRequest } from '../dtos/wishlist.dto';
 import { IUser } from '../models/mongodb/User.mongo';
 import { MongoUsersModel } from '../models/mongodb/init-models.mongo';
+import { AuthenticationError } from '../utils/customErrors';
 
 class WishListController {
   public wishlistService = new WishListService();
@@ -22,7 +23,7 @@ class WishListController {
       const userData = req.user as unknown as IUser;
       const pageNumber = req.query.pageNumber as string;
       if (!userData) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const user = await MongoUsersModel.findById(userData._id);
       if (!user) {
@@ -41,7 +42,7 @@ class WishListController {
       const { userId } = req.body;
 
       if (!userId) {
-        throw new Error('User not logged in');
+        throw new AuthenticationError('User not logged in');
       }
       const user = await MongoUsersModel.findById(userId);
       if (!user) {

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -4,7 +4,12 @@ import { logger } from '../utils/logger';
 
 const errorMiddleware = (error: HttpException, req: Request, res: Response, next: NextFunction) => {
   try {
-    const status: number = error.status || 500;
+    let status: number = error.status || 500;
+    // Map semantic error types (from utils/customErrors) to HTTP status codes.
+    // Without this, a thrown AuthenticationError has no `.status` and falls
+    // through to 500 instead of the correct 401/403.
+    if (error.name === 'AuthenticationError') status = 401;
+    if (error.name === 'AuthorizationError') status = 403;
     const message: string = error.message || 'Something went wrong';
     const stack = new Error().stack;
     const details = stack?.split('\n')[2]?.trim().split(' (')[1]?.slice(0, -1);


### PR DESCRIPTION
## Problem

Unauthenticated requests to protected endpoints (`/wishlist`, `my-account`, `/history`, etc.) returned **HTTP 500** instead of **401**.

The response body was correct:

```json
{"message":"User not logged in"}
```

However, the status code was wrong, so the browser console filled with red errors that looked like a production outage when the user was simply not logged in.

## Root Cause

`src/middlewares/error.middleware.ts` derives the status from:

```ts
error.status || 500
```

Only `HttpException` sets `.status`.

Ten controller auth-checks threw a plain:

```ts
new Error('User not logged in')
```

Since plain `Error` has no `.status`, those errors fell through to **500**.

## Fix

* **`error.middleware.ts`**: map error type to status:

  * `AuthenticationError` → `401`
  * `AuthorizationError` → `403`

* **Controllers**: throw the already-existing-but-unused `AuthenticationError` from `src/utils/customErrors.ts` instead of a bare `Error` at all 10 sites.

Auth-detection logic (`req.user` / `req.body.userId`) is unchanged.

Affected files:

* `wishlist.controller.ts` ×2
* `audioDescriptions.controller.ts` ×3
* `audioClips.controller.ts` ×2
* `users.controller.ts` ×3

## Verification

Tested end-to-end against the locally-running API. The real prefix is `/api`.

Protected endpoints, unauthenticated:

* `get-user-wishlist`
* `get-my-descriptions`
* `get-my-draft-descriptions`
* `get-Visited-Videos-History`
* `get-user-Ai-DescriptionRequests`

Result:

```http
401
```

```json
{"message":"User not logged in"}
```

Public endpoints unaffected:

* `wishlist/get-all-wishlist` → `201`
* `videos/home-videos` → `200`

TypeScript check:

```bash
tsc --noEmit
```

Result: clean.

## Notes / Out of Scope

* A route-layer `ensureAuthenticated` guard was considered but **not** adopted. Per-controller checks were kept.
* The frontend already shows graceful `"Log in to view…"` states. With this change, those calls now receive a clean **401** instead of **500**.
