### PR TITLE
fix(ai-pipeline): sweep stuck 'processing' requests + repair GPU heal…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import yaml from 'js-yaml';
 import fs from 'fs';
 import { initPassport, MongoAICaptionRequestModel, MongoVideosModel } from './models/mongodb/init-models.mongo';
 import { checkAndNotify, gpuStatusCronJob, videoStatusCheckJob } from './utils/cron.utils';
+import { stuckProcessingSweeperJob } from './utils/aiRequestSweeper.utils';
 import moment from 'moment';
 import YouTubeProxyRoute from './routes/youtube-proxy.route';
 import mongoose from 'mongoose';
@@ -147,6 +148,7 @@ class App {
     checkAndNotify();
     gpuStatusCronJob.start();
     videoStatusCheckJob.start();
+    stuckProcessingSweeperJob.start();
     this.setupVideoCountIntervals();
   }
 

--- a/src/utils/adminNotify.utils.ts
+++ b/src/utils/adminNotify.utils.ts
@@ -1,0 +1,16 @@
+import sendEmail from './emailService';
+import { GPU_NOTIFY_EMAILS } from '../config';
+import { logger } from './logger';
+
+/**
+ * Send an operational alert to the admin recipients (GPU_NOTIFY_EMAILS).
+ * Best-effort: a failing recipient is logged and never throws, so callers
+ * (cron jobs, the sweeper) can't be broken by an email failure.
+ */
+export const notifyAdmins = async (subject: string, text: string): Promise<void> => {
+  await Promise.all(
+    GPU_NOTIFY_EMAILS.map(email =>
+      sendEmail(email, subject, text).catch((err: any) => logger.error(`[notifyAdmins] failed to email ${email}: ${err?.message}`)),
+    ),
+  );
+};

--- a/src/utils/aiRequestSweeper.utils.ts
+++ b/src/utils/aiRequestSweeper.utils.ts
@@ -1,0 +1,61 @@
+import { CronJob } from 'cron';
+import { MongoAICaptionRequestModel } from '../models/mongodb/init-models.mongo';
+import GpuUtilsService from '../services/gpu_utils.service';
+import { notifyAdmins } from './adminNotify.utils';
+import { logger } from './logger';
+
+// How long an AICaptionRequest may sit in `processing` before we consider the
+// AI pipeline instance dead and fail the request out. The instance dying mid-job
+// never sends a completion/failure callback, so the record would otherwise stay
+// `processing` forever and wedge the queue (processNextInQueueLana bails while any
+// record is `processing`). There is no heartbeat, so this must comfortably exceed
+// the longest legitimate processing time.
+const STALE_PROCESSING_MS = 5 * 60 * 60 * 1000; // 5 hours
+
+/**
+ * Find AICaptionRequest records stuck in `processing` past the timeout and fail
+ * them out. Reuses GpuUtilsService.notifyAiDescriptionFailure, which emails every
+ * requester and then deletes the record so the user can re-request (which creates
+ * a fresh `pending`). Deleting the zombie also clears the queue's busy-check.
+ */
+export const sweepStuckAiCaptionRequests = async (): Promise<void> => {
+  const cutoff = new Date(Date.now() - STALE_PROCESSING_MS);
+
+  const stale = await MongoAICaptionRequestModel.find({ status: 'processing', updatedAt: { $lt: cutoff } }, { _id: 1, youtube_id: 1 });
+
+  if (!stale.length) return;
+  logger.info(`[sweeper] Found ${stale.length} AI caption request(s) stuck in processing > 5h`);
+
+  const gpuUtils = new GpuUtilsService();
+  const reaped: string[] = [];
+  for (const rec of stale) {
+    try {
+      // Atomic claim: only the run that actually flips processing->failed proceeds,
+      // so overlapping sweeps never email/delete the same record twice.
+      const claimed = await MongoAICaptionRequestModel.updateOne({ _id: rec._id, status: 'processing' }, { $set: { status: 'failed' } });
+      if (claimed.modifiedCount !== 1) continue;
+
+      await gpuUtils.notifyAiDescriptionFailure(
+        rec.youtube_id,
+        'Processing timed out — the AI service did not respond within 5 hours. Please try requesting it again.',
+      );
+      reaped.push(rec.youtube_id);
+      logger.info(`[sweeper] Failed out stuck request for ${rec.youtube_id}`);
+    } catch (err: any) {
+      logger.error(`[sweeper] Error failing out ${rec.youtube_id}: ${err?.message}`);
+    }
+  }
+
+  // One summary alert to admins per run — a strong "the AI instance may have died" signal.
+  if (reaped.length > 0) {
+    await notifyAdmins(
+      `[YDX] Swept ${reaped.length} stuck AI caption request(s)`,
+      `${reaped.length} AI caption request(s) were stuck in 'processing' for over 5 hours and have been failed out ` +
+        `(the AI pipeline instance may have died mid-job). Affected videos:\n${reaped.join('\n')}`,
+    );
+  }
+};
+
+// Run every 10 minutes (independent of the 5h staleness threshold). 6-field cron
+// (sec min hour dom mon dow); started explicitly from app.ts.
+export const stuckProcessingSweeperJob = new CronJob('0 */10 * * * *', sweepStuckAiCaptionRequests, null, false, 'America/Los_Angeles');

--- a/src/utils/cron.utils.ts
+++ b/src/utils/cron.utils.ts
@@ -1,8 +1,7 @@
 import { CronJob } from 'cron';
 import { checkGPUServerStatus } from './util';
-import sendEmail from './emailService';
 import { logger } from './logger';
-import { GPU_NOTIFY_EMAILS } from '../config';
+import { notifyAdmins } from './adminNotify.utils';
 import { checkAndUpdateVideoStatuses } from './video-status.utils';
 let previousStatus: any;
 // Function to check GPU server status and send an email for status transitions
@@ -12,21 +11,17 @@ export const checkAndNotify = async (): Promise<void> => {
   console.log(`GPU Server Status :: ${currentStatus}`);
   if (previousStatus !== undefined && currentStatus !== previousStatus) {
     if (previousStatus === true && currentStatus === false) {
-      GPU_NOTIFY_EMAILS.forEach(email =>
-        sendEmail(email, 'GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.'),
-      );
+      await notifyAdmins('GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.');
     } else {
-      GPU_NOTIFY_EMAILS.forEach(email =>
-        sendEmail(email, 'GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.'),
-      );
+      await notifyAdmins('GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.');
     }
   }
 
   previousStatus = currentStatus;
 };
-// Define a cron job to check the GPU server status every 15 seconds
+// Check the GPU server status every minute (6-field cron: sec min hour dom mon dow).
 export const gpuStatusCronJob = new CronJob(
-  '0 0 * * * *', // cronTime: Run every 15 seconds
+  '0 * * * * *', // cronTime: every minute, at second 0
   checkAndNotify, // Function to check and notify about GPU server status
   null, // onComplete
   true, // start the cron job immediately

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -75,7 +75,9 @@ export const getYouTubeVideoStatus = async (youtube_id: string): Promise<IVideo>
 export const checkGPUServerStatus = async (): Promise<boolean> => {
   try {
     if (GPU_URL === null) throw new Error('GPU_URL is not defined');
-    await axios.get(`${GPU_URL}/health_check`);
+    // AI service exposes GET /health (see AI-generated-AD server.py); the old
+    // /health_check path 404s, which made this always return false.
+    await axios.get(`${GPU_URL}/health`);
     return true;
   } catch (error) {
     console.error('Error checking GPU server status:', error.code);


### PR DESCRIPTION
## Stuck AI Caption Requests

When the AI pipeline instance dies mid-job, it never sends a completion or failure callback. As a result, the `AICaptionRequest` stays in `status: 'processing'` forever.

Because `processNextInQueueLana` exits early whenever any record is in `processing`, one zombie record can wedge the entire queue, leaving every later request stuck in `pending`.

This change adds a sweeper cron that runs every 10 minutes and fails out requests that have been stuck in `processing` for more than **5 hours**.

The sweeper reuses the existing `GpuUtilsService.notifyAiDescriptionFailure` flow, which:

* emails the requesters
* deletes the record so the user can re-request

Deleting the zombie record also releases the queue’s busy check, allowing the queue to continue processing later requests.

Records are claimed atomically by changing their status from `processing` to `failed`, so overlapping sweeper runs will not double-notify users.

---

## GPU Health Alerting

The health monitor was effectively broken.

`checkGPUServerStatus` was pinging:

```text
GPU_URL/health_check
```

However, the AI service only exposes:

```text
/health
```

Therefore, the GET request returned `404`, causing the health check to always return `false`. Since the up/down email alert only fires on status transitions, the alert never fired.

The cron schedule was also wrong: it ran hourly despite a comment saying it should run every 15 seconds.

Changes:

* `util.ts`: ping `/health` instead of `/health_check`
* `cron.utils.ts`: run the GPU check every minute
* `cron.utils.ts`: route alerts through a shared best-effort `notifyAdmins` helper
* `aiRequestSweeper`: send one summary admin alert per run when stuck requests are reaped

The sweeper alert provides an additional signal that the AI instance may have died, complementing the real-time health check.

---

## Out of Scope

Follow-up items:

* Add a unique index on `{ youtube_id, ai_user_id }` to prevent concurrent duplicates.
* Re-drive `pending` records orphaned by an API restart.
* Add automatic retry.
