### PR TITLE
Rebuild AI processing queue from Mongo on startup (YOUD-31)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import { initPassport, MongoAICaptionRequestModel, MongoVideosModel } from './mo
 import { checkAndNotify, gpuStatusCronJob, videoStatusCheckJob } from './utils/cron.utils';
 import moment from 'moment';
 import YouTubeProxyRoute from './routes/youtube-proxy.route';
+import UsersRoute from './routes/users.route';
 import mongoose from 'mongoose';
 
 class App {
@@ -40,6 +41,23 @@ class App {
     this.initializeSwagger();
     initPassport();
     this.initializeCronJobs();
+    this.initializeQueueRecovery(routes);
+  }
+
+  // Rebuild the in-memory AI-processing queue from Mongo once the DB is connected, so
+  // pending/orphaned requests survive a server restart. Reaches the single UserService
+  // instance the dispatcher actually uses (UsersRoute -> usersController.userService).
+  private initializeQueueRecovery(routes: Routes[]) {
+    const usersRoute = routes.find((r): r is UsersRoute => r instanceof UsersRoute);
+    if (!usersRoute) {
+      logger.warn('Queue recovery skipped: UsersRoute not found in routes');
+      return;
+    }
+    const run = () => usersRoute.usersController.userService.recoverPendingQueue().catch((err: any) => logger.error(`Queue recovery error: ${err.message}`));
+
+    // testDatabase() starts an un-awaited mongoose.connect(); run after it has connected.
+    if (mongoose.connection.readyState === 1) run();
+    else mongoose.connection.once('connected', run);
   }
 
   public listen() {

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -714,20 +714,25 @@ class UserService {
    * Startup recovery: rebuild the in-memory processing queue from Mongo so requests survive
    * a server restart (e.g. after a PR deploy). Called once, after Mongo connects.
    *
-   * Single-instance invariant (AI runs on one m5.large): this process is the only thing that
-   * can hold an in-flight pipeline, so any record still 'processing' at startup is an orphan
-   * from the previous (now-dead) process. We recover:
-   *   - orphaned 'processing' -> unconditionally (they were actively in-flight; most important)
+   * The AI pipeline runs as a SEPARATE process on its own instance and survives an api
+   * restart, so a 'processing' record at startup is NOT necessarily dead — a live pipeline
+   * may still be working on it and will call back to complete it. We therefore recover:
+   *   - STALE 'processing' (stuck past STALE_PROCESSING_TIMEOUT_MS — the pipeline that owned
+   *     it genuinely died) -> reclaim to 'pending' and re-drive. Fresh 'processing' is left
+   *     ALONE so we don't double-dispatch a job the AI box is still running.
    *   - 'pending' -> only those created within the last 24h (drops abandoned / legacy junk)
    */
   public async recoverPendingQueue(): Promise<void> {
     try {
-      // Reclaim orphans first, then flip them to 'pending' so the dispatcher's
-      // countDocuments('processing') in-flight count starts clean.
-      const orphans = await MongoAICaptionRequestModel.find({ status: 'processing' });
+      // Reclaim ONLY stale 'processing' (older than the stale threshold = its pipeline died);
+      // flip just those to 'pending' so the dispatcher's countDocuments('processing') count is
+      // accurate and they get re-driven. Fresh 'processing' is untouched — its live pipeline
+      // on the AI box will still call back.
+      const staleThreshold = new Date(Date.now() - UserService.STALE_PROCESSING_TIMEOUT_MS);
+      const orphans = await MongoAICaptionRequestModel.find({ status: 'processing', updatedAt: { $lt: staleThreshold } });
       if (orphans.length) {
-        await MongoAICaptionRequestModel.updateMany({ status: 'processing' }, { $set: { status: 'pending' } });
-        logger.info(`Queue recovery: reclaimed ${orphans.length} orphaned 'processing' request(s)`);
+        await MongoAICaptionRequestModel.updateMany({ _id: { $in: orphans.map(o => o._id) } }, { $set: { status: 'pending' } });
+        logger.info(`Queue recovery: reclaimed ${orphans.length} stale orphaned 'processing' request(s)`);
       }
 
       // Select: the reclaimed orphans + pending created within the recovery window.

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -708,6 +708,62 @@ class UserService {
     }
   }
 
+  private static readonly RECOVERY_WINDOW_MS = 24 * 60 * 60 * 1000; // only re-drive pending from the last 24h
+
+  /**
+   * Startup recovery: rebuild the in-memory processing queue from Mongo so requests survive
+   * a server restart (e.g. after a PR deploy). Called once, after Mongo connects.
+   *
+   * Single-instance invariant (AI runs on one m5.large): this process is the only thing that
+   * can hold an in-flight pipeline, so any record still 'processing' at startup is an orphan
+   * from the previous (now-dead) process. We recover:
+   *   - orphaned 'processing' -> unconditionally (they were actively in-flight; most important)
+   *   - 'pending' -> only those created within the last 24h (drops abandoned / legacy junk)
+   */
+  public async recoverPendingQueue(): Promise<void> {
+    try {
+      // Reclaim orphans first, then flip them to 'pending' so the dispatcher's
+      // countDocuments('processing') in-flight count starts clean.
+      const orphans = await MongoAICaptionRequestModel.find({ status: 'processing' });
+      if (orphans.length) {
+        await MongoAICaptionRequestModel.updateMany({ status: 'processing' }, { $set: { status: 'pending' } });
+        logger.info(`Queue recovery: reclaimed ${orphans.length} orphaned 'processing' request(s)`);
+      }
+
+      // Select: the reclaimed orphans + pending created within the recovery window.
+      const cutoff = new Date(Date.now() - UserService.RECOVERY_WINDOW_MS);
+      const toRecover = await MongoAICaptionRequestModel.find({
+        status: 'pending',
+        $or: [{ _id: { $in: orphans.map(o => o._id) } }, { createdAt: { $gte: cutoff } }],
+      }).sort({ createdAt: 1 });
+
+      let loaded = 0;
+      for (const doc of toRecover) {
+        const requesters = (doc.caption_requests ?? []) as unknown[];
+        const userId = requesters.length ? String(requesters[requesters.length - 1]) : '';
+        if (!userId) {
+          logger.warn(`Queue recovery: ${doc.youtube_id} has no requesting user; skipping`);
+          continue;
+        }
+        // Defensive: at startup the queue is empty, but guard against a double-enqueue anyway.
+        if (this.videoProcessingQueue.some(q => q.youtubeId === doc.youtube_id && q.aiUserId === doc.ai_user_id)) continue;
+
+        this.videoProcessingQueue.push({
+          youtubeId: doc.youtube_id,
+          userId,
+          aiUserId: doc.ai_user_id,
+          ydx_app_host: CURRENT_YDX_HOST, // unused by the dispatch path; safe default for recovered items
+        });
+        loaded++;
+      }
+      logger.info(`Queue recovery: loaded ${loaded} request(s) into the in-memory queue`);
+
+      if (loaded > 0) this.processNextInQueueLana(); // self-limits to AI_PIPELINE_CONCURRENCY
+    } catch (err: any) {
+      logger.error(`Queue recovery failed: ${err.message}`);
+    }
+  }
+
   //******** LANA CHANGE *********/
   private async processNextInQueueLana(): Promise<void> {
     // Re-entry guard: only one dispatch loop active at a time.


### PR DESCRIPTION
## Problem
The AI processing queue is held in memory (`videoProcessingQueue` in `users.service.ts`), so every server restart (e.g. a deploy) wipes accepted-but-unfinished requests. They are never picked back up — the dispatcher early-returns on an empty queue, so `pending` work stalls indefinitely. (YOUD-31)

## Fix
Add a one-time startup recovery that rebuilds the queue from MongoDB once the DB is connected:

- **Reclaim orphans.** Single-instance invariant: any record still `processing` at startup belongs to the previous (dead) process. Flip them `processing → pending` so the dispatcher's `countDocuments('processing')` in-flight count starts clean.
- **Reload the queue** with the reclaimed orphans + `pending` requests created within the last 24h (drops abandoned/legacy requests), rebuilding each queue item from the stored doc (`youtube_id`, `ai_user_id`, requesting user from `caption_requests`). Skips docs with no requesting user; guards against double-enqueue.
- **Kick the dispatcher**, which self-limits to `AI_PIPELINE_CONCURRENCY`.

Wired from `app.ts` on the mongoose `connected` event, against the single `UserService` instance the dispatcher uses (`UsersRoute → usersController.userService`).

## Scope
- `src/services/users.service.ts` — new `recoverPendingQueue()`
- `src/app.ts` — startup wiring

No changes to routes, schema, or the AI pipeline. `tsc --noEmit` clean.