### PR TITLE
chore: remove dead GPU health monitor (GPU_URL never set)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import options from './swaggerOptions';
 import yaml from 'js-yaml';
 import fs from 'fs';
 import { initPassport, MongoAICaptionRequestModel, MongoVideosModel } from './models/mongodb/init-models.mongo';
-import { checkAndNotify, gpuStatusCronJob, videoStatusCheckJob } from './utils/cron.utils';
+import { videoStatusCheckJob } from './utils/cron.utils';
 import { stuckProcessingSweeperJob } from './utils/aiRequestSweeper.utils';
 import moment from 'moment';
 import YouTubeProxyRoute from './routes/youtube-proxy.route';
@@ -163,8 +163,6 @@ class App {
     console.log('Initializing Cron Jobs');
     logger.info('Initializing Cron Jobs');
     this.resetNumOfVideos();
-    checkAndNotify();
-    gpuStatusCronJob.start();
     videoStatusCheckJob.start();
     stuckProcessingSweeperJob.start();
     this.setupVideoCountIntervals();

--- a/src/utils/cron.utils.ts
+++ b/src/utils/cron.utils.ts
@@ -1,32 +1,6 @@
 import { CronJob } from 'cron';
-import { checkGPUServerStatus } from './util';
 import { logger } from './logger';
-import { notifyAdmins } from './adminNotify.utils';
 import { checkAndUpdateVideoStatuses } from './video-status.utils';
-let previousStatus: any;
-// Function to check GPU server status and send an email for status transitions
-export const checkAndNotify = async (): Promise<void> => {
-  const currentStatus = await checkGPUServerStatus();
-  logger.info(`GPU Server Status :: ${currentStatus}`);
-  console.log(`GPU Server Status :: ${currentStatus}`);
-  if (previousStatus !== undefined && currentStatus !== previousStatus) {
-    if (previousStatus === true && currentStatus === false) {
-      await notifyAdmins('GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.');
-    } else {
-      await notifyAdmins('GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.');
-    }
-  }
-
-  previousStatus = currentStatus;
-};
-// Check the GPU server status every minute (6-field cron: sec min hour dom mon dow).
-export const gpuStatusCronJob = new CronJob(
-  '0 * * * * *', // every minute at second 0
-  checkAndNotify, // Function to check and notify about GPU server status
-  null, // onComplete
-  true, // start the cron job immediately
-  'America/Los_Angeles', // timeZone
-);
 
 export const videoStatusCheckJob = new CronJob('0 0 * * *', async () => {
   logger.info('Starting scheduled video status check');

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,8 +1,6 @@
-import axios from 'axios';
 import { MongoUsersModel, MongoVideosModel } from '../models/mongodb/init-models.mongo';
 import { IVideo } from '../models/mongodb/Videos.mongo';
 import { getVideoDataByYoutubeId } from './videos.util';
-import { GPU_URL } from '../config';
 import moment from 'moment';
 import { logger } from './logger';
 
@@ -69,19 +67,6 @@ export const getYouTubeVideoStatus = async (youtube_id: string): Promise<IVideo>
       updated_at: nowUtc(),
     });
     return await newVid.save();
-  }
-};
-
-export const checkGPUServerStatus = async (): Promise<boolean> => {
-  try {
-    if (GPU_URL === null) throw new Error('GPU_URL is not defined');
-    // AI service exposes GET /health (see AI-generated-AD server.py); the old
-    // /health_check path 404s, which made this always report the server as down.
-    await axios.get(`${GPU_URL}/health`);
-    return true;
-  } catch (error) {
-    console.error('Error checking GPU server status:', error.code);
-    return false;
   }
 };
 


### PR DESCRIPTION
The GPU health monitor (`checkGPUServerStatus` + `gpuStatusCronJob` + `checkAndNotify`) has been dead since it was added ~2 years ago: **`GPU_URL` is unset on both dev and prod**, so the check always hit an undefined URL, always reported the AI server 'down', and just logged `GPU Server Status :: false` on a timer (never firing a useful up/down alert).

This removes the monitor and its wiring (util.ts `checkGPUServerStatus`, cron.utils.ts `checkAndNotify`/`gpuStatusCronJob`, and the app.ts startup calls). No behavior is lost — it produced only noise.

The live AI service is reached via `AI_SERVICE_URL` (which /status now uses); a proper health monitor can be reintroduced against that endpoint separately if wanted. Keeps `videoStatusCheckJob` and the sweeper's `notifyAdmins`.