### PR TITLE
Promote dev to main: /status-aware stuck-request sweeper + remove dead GPU health monitor

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import options from './swaggerOptions';
 import yaml from 'js-yaml';
 import fs from 'fs';
 import { initPassport, MongoAICaptionRequestModel, MongoVideosModel } from './models/mongodb/init-models.mongo';
-import { checkAndNotify, gpuStatusCronJob, videoStatusCheckJob } from './utils/cron.utils';
+import { videoStatusCheckJob } from './utils/cron.utils';
 import { stuckProcessingSweeperJob } from './utils/aiRequestSweeper.utils';
 import moment from 'moment';
 import YouTubeProxyRoute from './routes/youtube-proxy.route';
@@ -163,8 +163,6 @@ class App {
     console.log('Initializing Cron Jobs');
     logger.info('Initializing Cron Jobs');
     this.resetNumOfVideos();
-    checkAndNotify();
-    gpuStatusCronJob.start();
     videoStatusCheckJob.start();
     stuckProcessingSweeperJob.start();
     this.setupVideoCountIntervals();

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import yaml from 'js-yaml';
 import fs from 'fs';
 import { initPassport, MongoAICaptionRequestModel, MongoVideosModel } from './models/mongodb/init-models.mongo';
 import { checkAndNotify, gpuStatusCronJob, videoStatusCheckJob } from './utils/cron.utils';
+import { stuckProcessingSweeperJob } from './utils/aiRequestSweeper.utils';
 import moment from 'moment';
 import YouTubeProxyRoute from './routes/youtube-proxy.route';
 import UsersRoute from './routes/users.route';
@@ -165,6 +166,7 @@ class App {
     checkAndNotify();
     gpuStatusCronJob.start();
     videoStatusCheckJob.start();
+    stuckProcessingSweeperJob.start();
     this.setupVideoCountIntervals();
   }
 

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -690,23 +690,14 @@ class UserService {
     }
   }
 
-  private static readonly STALE_PROCESSING_TIMEOUT_MS = 30 * 60 * 1000;
+  // 4h: an AI pipeline can legitimately run for hours on the CPU-only box, so a shorter
+  // window false-fails live work. Liveness is confirmed via the AI /status endpoint;
+  // this timeout is only the backstop for when the AI can't be reached.
+  private static readonly STALE_PROCESSING_TIMEOUT_MS = 4 * 60 * 60 * 1000;
 
-  private async recoverStaleProcessing(): Promise<void> {
-    const staleThreshold = new Date(Date.now() - UserService.STALE_PROCESSING_TIMEOUT_MS);
-    const staleRecords = await MongoAICaptionRequestModel.find({
-      status: 'processing',
-      updatedAt: { $lt: staleThreshold },
-    });
-
-    for (const record of staleRecords) {
-      const staleDuration = Date.now() - new Date((record as any).updatedAt).getTime();
-      logger.warn(`Stale processing detected for ${record.youtube_id} (stuck for ${Math.round(staleDuration / 60000)} min). Marking as failed.`);
-      await MongoAICaptionRequestModel.updateOne({ _id: record._id }, { $set: { status: 'failed' } });
-      const gpuUtils = new GpuUtilsService();
-      await gpuUtils.notifyAiDescriptionFailure(record.youtube_id, 'The processing timed out. The server may have been busy or encountered an error.');
-    }
-  }
+  // Failing out stale 'processing' records lives in the standalone cron sweeper
+  // (utils/aiRequestSweeper.utils.ts), which is /status-aware. recoverStaleProcessing
+  // was removed to avoid two mechanisms judging the same thing.
 
   private static readonly RECOVERY_WINDOW_MS = 24 * 60 * 60 * 1000; // only re-drive pending from the last 24h
 
@@ -777,10 +768,10 @@ class UserService {
 
     this.isDispatching = true;
     try {
-      // 1. Recover any stale 'processing' records so they don't permanently block dispatch.
-      await this.recoverStaleProcessing();
+      // Stale 'processing' cleanup is handled by the /status-aware cron sweeper
+      // (utils/aiRequestSweeper.utils.ts), not inline here.
 
-      // 2. Read in-flight count. Mongo is the source of truth — survives api restarts.
+      // Read in-flight count. Mongo is the source of truth — survives api restarts.
       let inFlight = await MongoAICaptionRequestModel.countDocuments({ status: 'processing' });
 
       // 3. Dispatch as many items as slots allow.

--- a/src/utils/adminNotify.utils.ts
+++ b/src/utils/adminNotify.utils.ts
@@ -1,0 +1,16 @@
+import sendEmail from './emailService';
+import { GPU_NOTIFY_EMAILS } from '../config';
+import { logger } from './logger';
+
+/**
+ * Send an operational alert to the admin recipients (GPU_NOTIFY_EMAILS).
+ * Best-effort: a failing recipient is logged and never throws, so callers
+ * (cron jobs, the sweeper) can't be broken by an email failure.
+ */
+export const notifyAdmins = async (subject: string, text: string): Promise<void> => {
+  await Promise.all(
+    GPU_NOTIFY_EMAILS.map(email =>
+      sendEmail(email, subject, text).catch((err: any) => logger.error(`[notifyAdmins] failed to email ${email}: ${err?.message}`)),
+    ),
+  );
+};

--- a/src/utils/aiRequestSweeper.utils.ts
+++ b/src/utils/aiRequestSweeper.utils.ts
@@ -1,0 +1,77 @@
+import { CronJob } from 'cron';
+import axios from 'axios';
+import { MongoAICaptionRequestModel } from '../models/mongodb/init-models.mongo';
+import GpuUtilsService from '../services/gpu_utils.service';
+import { notifyAdmins } from './adminNotify.utils';
+import { logger } from './logger';
+
+// How long an AICaptionRequest may sit in `processing` before we get suspicious.
+// This is only a "start checking" threshold, not a death sentence: a record past it
+// is confirmed alive-or-dead against the AI /status endpoint below. A record still
+// running there is left alone (the AI pipeline can legitimately run for hours on the
+// CPU-only box). Must comfortably exceed the longest legitimate processing time.
+const STALE_PROCESSING_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+/**
+ * Find AICaptionRequest records stuck in `processing` past the timeout and, for the
+ * ones the AI service is NOT actually running (per GET /status), fail them out.
+ * Reuses GpuUtilsService.notifyAiDescriptionFailure, which emails every requester and
+ * then deletes the record so the user can re-request (which creates a fresh `pending`).
+ * Deleting the zombie also clears the queue's busy-check.
+ */
+export const sweepStuckAiCaptionRequests = async (): Promise<void> => {
+  const cutoff = new Date(Date.now() - STALE_PROCESSING_MS);
+
+  const stale = await MongoAICaptionRequestModel.find({ status: 'processing', updatedAt: { $lt: cutoff } }, { _id: 1, youtube_id: 1 });
+
+  if (!stale.length) return;
+  logger.info(`[sweeper] Found ${stale.length} AI caption request(s) stuck in processing > 4h`);
+
+  // Confirm liveness against the AI service before failing anything: /status reports the
+  // video_ids it is really running (from the actual test_pipeline processes). If we can't
+  // reach it, do NOT reap on a guess — skip this run; the next one (10 min later) retries.
+  const aiServiceUrl = process.env.AI_SERVICE_URL || 'http://localhost:8000';
+  let active: string[];
+  try {
+    const statusResp = await axios.get(`${aiServiceUrl}/status`, { timeout: 5000 });
+    active = statusResp.data?.active ?? [];
+  } catch (err: any) {
+    logger.warn(`[sweeper] /status unreachable (${err?.message}); skipping this run.`);
+    return;
+  }
+
+  const gpuUtils = new GpuUtilsService();
+  const reaped: string[] = [];
+  for (const rec of stale) {
+    if (active.includes(rec.youtube_id)) continue; // AI is still running it — not dead
+
+    try {
+      // Atomic claim: only the run that actually flips processing->failed proceeds,
+      // so overlapping sweeps never email/delete the same record twice.
+      const claimed = await MongoAICaptionRequestModel.updateOne({ _id: rec._id, status: 'processing' }, { $set: { status: 'failed' } });
+      if (claimed.modifiedCount !== 1) continue;
+
+      await gpuUtils.notifyAiDescriptionFailure(
+        rec.youtube_id,
+        'Processing timed out — the AI service is no longer working on this video. Please try requesting it again.',
+      );
+      reaped.push(rec.youtube_id);
+      logger.info(`[sweeper] Failed out stuck request for ${rec.youtube_id}`);
+    } catch (err: any) {
+      logger.error(`[sweeper] Error failing out ${rec.youtube_id}: ${err?.message}`);
+    }
+  }
+
+  // One summary alert to admins per run — a strong "the AI instance may have died" signal.
+  if (reaped.length > 0) {
+    await notifyAdmins(
+      `[YDX] Swept ${reaped.length} stuck AI caption request(s)`,
+      `${reaped.length} AI caption request(s) were stuck in 'processing' past the timeout and are not running ` +
+        `on the AI service (it may have died mid-job). They have been failed out. Affected videos:\n${reaped.join('\n')}`,
+    );
+  }
+};
+
+// Run every 10 minutes (independent of the staleness threshold). 6-field cron
+// (sec min hour dom mon dow); started explicitly from app.ts.
+export const stuckProcessingSweeperJob = new CronJob('0 */10 * * * *', sweepStuckAiCaptionRequests, null, false, 'America/Los_Angeles');

--- a/src/utils/cron.utils.ts
+++ b/src/utils/cron.utils.ts
@@ -1,32 +1,6 @@
 import { CronJob } from 'cron';
-import { checkGPUServerStatus } from './util';
 import { logger } from './logger';
-import { notifyAdmins } from './adminNotify.utils';
 import { checkAndUpdateVideoStatuses } from './video-status.utils';
-let previousStatus: any;
-// Function to check GPU server status and send an email for status transitions
-export const checkAndNotify = async (): Promise<void> => {
-  const currentStatus = await checkGPUServerStatus();
-  logger.info(`GPU Server Status :: ${currentStatus}`);
-  console.log(`GPU Server Status :: ${currentStatus}`);
-  if (previousStatus !== undefined && currentStatus !== previousStatus) {
-    if (previousStatus === true && currentStatus === false) {
-      await notifyAdmins('GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.');
-    } else {
-      await notifyAdmins('GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.');
-    }
-  }
-
-  previousStatus = currentStatus;
-};
-// Check the GPU server status every minute (6-field cron: sec min hour dom mon dow).
-export const gpuStatusCronJob = new CronJob(
-  '0 * * * * *', // every minute at second 0
-  checkAndNotify, // Function to check and notify about GPU server status
-  null, // onComplete
-  true, // start the cron job immediately
-  'America/Los_Angeles', // timeZone
-);
 
 export const videoStatusCheckJob = new CronJob('0 0 * * *', async () => {
   logger.info('Starting scheduled video status check');

--- a/src/utils/cron.utils.ts
+++ b/src/utils/cron.utils.ts
@@ -1,8 +1,7 @@
 import { CronJob } from 'cron';
 import { checkGPUServerStatus } from './util';
-import sendEmail from './emailService';
 import { logger } from './logger';
-import { GPU_NOTIFY_EMAILS } from '../config';
+import { notifyAdmins } from './adminNotify.utils';
 import { checkAndUpdateVideoStatuses } from './video-status.utils';
 let previousStatus: any;
 // Function to check GPU server status and send an email for status transitions
@@ -12,21 +11,17 @@ export const checkAndNotify = async (): Promise<void> => {
   console.log(`GPU Server Status :: ${currentStatus}`);
   if (previousStatus !== undefined && currentStatus !== previousStatus) {
     if (previousStatus === true && currentStatus === false) {
-      GPU_NOTIFY_EMAILS.forEach(email =>
-        sendEmail(email, 'GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.'),
-      );
+      await notifyAdmins('GPU Server is Down', 'YDX Server is unable to connect to the GPU server. Please check the GPU server.');
     } else {
-      GPU_NOTIFY_EMAILS.forEach(email =>
-        sendEmail(email, 'GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.'),
-      );
+      await notifyAdmins('GPU Server is Up', 'YDX Server is able to connect to the GPU server. GPU server is up and running.');
     }
   }
 
   previousStatus = currentStatus;
 };
-// Define a cron job to check the GPU server status every 15 seconds
+// Check the GPU server status every minute (6-field cron: sec min hour dom mon dow).
 export const gpuStatusCronJob = new CronJob(
-  '0 0 * * * *', // cronTime: Run every 15 seconds
+  '0 * * * * *', // every minute at second 0
   checkAndNotify, // Function to check and notify about GPU server status
   null, // onComplete
   true, // start the cron job immediately

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -75,7 +75,9 @@ export const getYouTubeVideoStatus = async (youtube_id: string): Promise<IVideo>
 export const checkGPUServerStatus = async (): Promise<boolean> => {
   try {
     if (GPU_URL === null) throw new Error('GPU_URL is not defined');
-    await axios.get(`${GPU_URL}/health_check`);
+    // AI service exposes GET /health (see AI-generated-AD server.py); the old
+    // /health_check path 404s, which made this always report the server as down.
+    await axios.get(`${GPU_URL}/health`);
     return true;
   } catch (error) {
     console.error('Error checking GPU server status:', error.code);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,8 +1,6 @@
-import axios from 'axios';
 import { MongoUsersModel, MongoVideosModel } from '../models/mongodb/init-models.mongo';
 import { IVideo } from '../models/mongodb/Videos.mongo';
 import { getVideoDataByYoutubeId } from './videos.util';
-import { GPU_URL } from '../config';
 import moment from 'moment';
 import { logger } from './logger';
 
@@ -69,19 +67,6 @@ export const getYouTubeVideoStatus = async (youtube_id: string): Promise<IVideo>
       updated_at: nowUtc(),
     });
     return await newVid.save();
-  }
-};
-
-export const checkGPUServerStatus = async (): Promise<boolean> => {
-  try {
-    if (GPU_URL === null) throw new Error('GPU_URL is not defined');
-    // AI service exposes GET /health (see AI-generated-AD server.py); the old
-    // /health_check path 404s, which made this always report the server as down.
-    await axios.get(`${GPU_URL}/health`);
-    return true;
-  } catch (error) {
-    console.error('Error checking GPU server status:', error.code);
-    return false;
   }
 };
 


### PR DESCRIPTION
## What

Promotes two changes that have been running on dev since 2026-07-04 (#113, #114):

### 1. /status-aware stuck-request sweeper (#113)
- Replaces the old inline `recoverStaleProcessing` (30-min timeout, no liveness check) with a cron sweeper `sweepStuckAiCaptionRequests` (`utils/aiRequestSweeper.utils.ts`, every 10 min).
- A `processing` request is only failed if it is past **4h** AND confirmed absent from the AI service's `GET /status` active list. If `/status` is unreachable, the run is skipped — no reaping on a guess.
- Fixes the bug where in-flight CPU pipelines (which routinely exceed 30 min) were falsely failed and deleted while still running.
- Unifies the stale threshold to 4h across the sweeper and `recoverPendingQueue`.
- Adds `notifyAdmins` helper; failed requests still trigger the user failure email + admin summary.

### 2. Remove dead GPU health monitor (#114)
- `GPU_URL` has never been set on dev or prod, so `checkGPUServerStatus`/`gpuStatusCronJob` has been dead code for ~2 years — it only logged `GPU Server Status :: false` on a timer.
- Deletes the monitor and its cron wiring; keeps `videoStatusCheckJob` and the sweeper's admin notifications.

## Verification on dev

- Stable since 2026-07-04 (no crash/restart loop after redeploy).
- `GPU Server Status` log noise: gone.
- Sweeper running healthy (silent no-op with 0 stuck `processing` records).

## Deploy notes

After merge: trigger the GitLab mirror sync ("Update now") if not picked up within ~30 min, then manually recreate the prod backend container (deploy does not restart it). Verify on prod: GPU log noise gone + sweeper cron healthy.