### PR TITLE
Profile opt-in: add save endpoint and two notification fields

### DIFF
--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -99,6 +99,18 @@ class UsersController {
     }
   };
 
+  public updateOptIn = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId: string = req.body.id;
+      const choices: boolean[] = req.body.choices;
+      const updatedUser = await this.userService.updateOptIn(userId, choices);
+
+      res.status(200).json({ result: updatedUser, message: 'Opt-in choices updated' });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   /**
    * @swagger
    * /users/add-new-user:

--- a/src/models/mongodb/User.mongo.ts
+++ b/src/models/mongodb/User.mongo.ts
@@ -25,6 +25,8 @@ interface IUser extends Document {
   dialects: string;
   name: string;
   opt_in: boolean;
+  opt_in_wishlist_published: boolean;
+  opt_in_ai_feedback: boolean;
   picture: string;
   policy_review: boolean;
   token: string;
@@ -75,6 +77,16 @@ const UserSchema: Schema = new Schema(
     opt_in: {
       type: Boolean,
       required: true,
+      default: false,
+    },
+    opt_in_wishlist_published: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    opt_in_ai_feedback: {
+      type: Boolean,
+      required: false,
       default: false,
     },
     picture: {

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -31,6 +31,7 @@ class UsersRoute implements Routes {
     this.router.get(`${this.path}/get-Visited-Videos-History`, this.usersController.getVisitedVideosHistory);
     this.router.post(`${this.path}/pipeline-failure`, this.usersController.handlePipelineFailure);
     this.router.post(`${this.path}/request-ai-descriptions-with-lana`, this.usersController.requestAiDescriptionsWithLana);
+    this.router.post(`${this.path}/updateoptin`, this.usersController.updateOptIn);
 
     this.router.get(`${this.path}/:userId`, this.usersController.getUserById);
   }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -76,6 +76,32 @@ class UserService {
     }
   }
 
+  public async updateOptIn(userId: string, choices: boolean[]): Promise<IUser> {
+    if (isEmpty(userId)) throw new HttpException(400, 'UserId is empty');
+    if (!Array.isArray(choices)) throw new HttpException(400, 'choices must be an array');
+
+    // opt_in is the overall flag (true if any option selected); the two boolean
+    // fields persist each checkbox individually. choices[0] = wishlist published,
+    // choices[1] = automated AI feedback.
+    const optedIn = choices.some(Boolean);
+
+    const updatedUser = await MongoUsersModel.findByIdAndUpdate(
+      userId,
+      {
+        $set: {
+          opt_in: optedIn,
+          opt_in_wishlist_published: !!choices[0],
+          opt_in_ai_feedback: !!choices[1],
+          policy_review: true,
+          updated_at: nowUtc(),
+        },
+      },
+      { new: true },
+    );
+    if (!updatedUser) throw new HttpException(404, "User doesn't exist");
+    return updatedUser;
+  }
+
   public async createUser(userData: CreateUserDto): Promise<IUser | UsersAttributes> {
     if (isEmpty(userData)) throw new HttpException(400, 'userData is empty');
 


### PR DESCRIPTION
## Description
Backend support for the Profile notification opt-in save button (frontend: YouDescribeX-app#175).

- Add an endpoint to persist the user's profile opt-in choices
- Add two fields to the User model: `opt_in_wishlist_published`, `opt_in_ai_feedback`
- Wire controller/service/route to load and save each field

Touches: `users.controller.ts`, `User.mongo.ts`, `users.route.ts`, `users.service.ts` (4 files, +51).

## Motivation and Context
The Profile page's Save button previously had no backend to store choices. This adds the persistence so each checkbox round-trips per user.

## How has this been tested?
- `CI=false npm run build` (tsc) passes cleanly.
- Verified end-to-end with the app against the local API (:4001): choices save and reload correctly.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project.