### PR TITLE
Promote dev to main: unified auth middleware (#116) + opt-in save endpoint (#117)

### DIFF
--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -99,6 +99,18 @@ class UsersController {
     }
   };
 
+  public updateOptIn = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId: string = req.body.id;
+      const choices: boolean[] = req.body.choices;
+      const updatedUser = await this.userService.updateOptIn(userId, choices);
+
+      res.status(200).json({ result: updatedUser, message: 'Opt-in choices updated' });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   /**
    * @swagger
    * /users/add-new-user:

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,3 +1,6 @@
+// xiao: unified session guard — passes when passport has populated req.user from the session cookie.
+// Throws AuthenticationError which error.middleware.ts maps to HTTP 401.
+// This gives the frontend 401 interceptor the signal it needs to detect expired sessions.
 import { NextFunction, Request, Response } from 'express';
 import { AuthenticationError } from '../utils/customErrors';
 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from 'express';
+import { AuthenticationError } from '../utils/customErrors';
+
+const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    throw new AuthenticationError('Authentication required');
+  }
+  next();
+};
+
+export default authMiddleware;

--- a/src/models/mongodb/User.mongo.ts
+++ b/src/models/mongodb/User.mongo.ts
@@ -25,6 +25,8 @@ interface IUser extends Document {
   dialects: string;
   name: string;
   opt_in: boolean;
+  opt_in_wishlist_published: boolean;
+  opt_in_ai_feedback: boolean;
   picture: string;
   policy_review: boolean;
   token: string;
@@ -75,6 +77,16 @@ const UserSchema: Schema = new Schema(
     opt_in: {
       type: Boolean,
       required: true,
+      default: false,
+    },
+    opt_in_wishlist_published: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    opt_in_ai_feedback: {
+      type: Boolean,
+      required: false,
       default: false,
     },
     picture: {

--- a/src/routes/audioClips.route.ts
+++ b/src/routes/audioClips.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { upload } from '../utils/audioClips.util';
 import { Routes } from '../interfaces/routes.interface';
 import { AudioClipsController } from '../controllers/audioClips.controller';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class AudioClipsRoute implements Routes {
   public path = '/audio-clips';
@@ -13,17 +14,17 @@ class AudioClipsRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/processAllClipsInDB/:adId`, this.audioClipController.processAllClipsInDB);
-    this.router.put(`${this.path}/update-clip-title/:clipId`, this.audioClipController.updateAudioClipTitle);
-    this.router.put(`${this.path}/update-clip-playback-type/:clipId`, this.audioClipController.updateAudioClipPlaybackType);
-    this.router.put(`${this.path}/update-clip-start-time/:clipId`, this.audioClipController.updateAudioClipStartTime);
-    this.router.put(`${this.path}/update-clip-description/:clipId`, this.audioClipController.updateAudioClipDescription);
-    this.router.put(`${this.path}/record-replace-clip-audio/:clipId`, upload.single('file'), this.audioClipController.updateClipAudioPath);
-    this.router.post(`${this.path}/add-new-clip/:adId`, upload.single('file'), this.audioClipController.addNewAudioClip);
-    this.router.delete(`${this.path}/delete-clip/:clipId`, this.audioClipController.deleteAudioClip);
-    this.router.post(`${this.path}/undo-last-deleted`, this.audioClipController.undoDeletedAudioClip);
+    this.router.get(`${this.path}/processAllClipsInDB/:adId`, authMiddleware, this.audioClipController.processAllClipsInDB);
+    this.router.put(`${this.path}/update-clip-title/:clipId`, authMiddleware, this.audioClipController.updateAudioClipTitle);
+    this.router.put(`${this.path}/update-clip-playback-type/:clipId`, authMiddleware, this.audioClipController.updateAudioClipPlaybackType);
+    this.router.put(`${this.path}/update-clip-start-time/:clipId`, authMiddleware, this.audioClipController.updateAudioClipStartTime);
+    this.router.put(`${this.path}/update-clip-description/:clipId`, authMiddleware, this.audioClipController.updateAudioClipDescription);
+    this.router.put(`${this.path}/record-replace-clip-audio/:clipId`, authMiddleware, upload.single('file'), this.audioClipController.updateClipAudioPath);
+    this.router.post(`${this.path}/add-new-clip/:adId`, authMiddleware, upload.single('file'), this.audioClipController.addNewAudioClip);
+    this.router.delete(`${this.path}/delete-clip/:clipId`, authMiddleware, this.audioClipController.deleteAudioClip);
+    this.router.post(`${this.path}/undo-last-deleted`, authMiddleware, this.audioClipController.undoDeletedAudioClip);
     this.router.get(`${this.path}/get-playback-type/:clipId`, this.audioClipController.getAudioClipPlaybackType);
-    this.router.post(`${this.path}/switch-to-tts/:clipId`, this.audioClipController.switchToTTS);
+    this.router.post(`${this.path}/switch-to-tts/:clipId`, authMiddleware, this.audioClipController.switchToTTS);
   }
 }
 

--- a/src/routes/audioClips.route.ts
+++ b/src/routes/audioClips.route.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { upload } from '../utils/audioClips.util';
 import { Routes } from '../interfaces/routes.interface';
 import { AudioClipsController } from '../controllers/audioClips.controller';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class AudioClipsRoute implements Routes {
   public path = '/audio-clips';

--- a/src/routes/audioDescriptionRating.route.ts
+++ b/src/routes/audioDescriptionRating.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import AudioDescriptionsRatingController from '../controllers/audioDescriptionRating.controller';
 import { Routes } from '../interfaces/routes.interface';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class AudioDescriptionRatingRoute implements Routes {
   public path = '/audio-descriptions/ratings';
@@ -12,8 +13,8 @@ class AudioDescriptionRatingRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.post(`${this.path}/addOne/:audioDescriptionId`, this.audioDescriptionsRatingController.addOne);
-    this.router.get(`${this.path}/user/:audioDescriptionId`, this.audioDescriptionsRatingController.getUserRating);
+    this.router.post(`${this.path}/addOne/:audioDescriptionId`, authMiddleware, this.audioDescriptionsRatingController.addOne);
+    this.router.get(`${this.path}/user/:audioDescriptionId`, authMiddleware, this.audioDescriptionsRatingController.getUserRating);
   }
 }
 

--- a/src/routes/audioDescriptionRating.route.ts
+++ b/src/routes/audioDescriptionRating.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import AudioDescriptionsRatingController from '../controllers/audioDescriptionRating.controller';
 import { Routes } from '../interfaces/routes.interface';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class AudioDescriptionRatingRoute implements Routes {
   public path = '/audio-descriptions/ratings';

--- a/src/routes/audio_descriptions.route.ts
+++ b/src/routes/audio_descriptions.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import AudioDescriptionsController from '../controllers/audioDescriptions.controller';
 import { Routes } from '../interfaces/routes.interface';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class AudioDescriptionsRoute implements Routes {
   public path = '/audio-descriptions';

--- a/src/routes/audio_descriptions.route.ts
+++ b/src/routes/audio_descriptions.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import AudioDescriptionsController from '../controllers/audioDescriptions.controller';
 import { Routes } from '../interfaces/routes.interface';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class AudioDescriptionsRoute implements Routes {
   public path = '/audio-descriptions';
@@ -12,16 +13,16 @@ class AudioDescriptionsRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/get-user-ad/:videoId&:adId`, this.audioDescriptionsController.getUserAudioDescriptionData);
+    this.router.get(`${this.path}/get-user-ad/:videoId&:adId`, authMiddleware, this.audioDescriptionsController.getUserAudioDescriptionData);
     this.router.post(`${this.path}/newaidescription`, this.audioDescriptionsController.newAiDescription);
     this.router.post(`${this.path}/aidescription-failure`, this.audioDescriptionsController.aidescriptionFailure);
-    this.router.delete(`${this.path}/delete-user-ad-audios/:youtubeVideoId&:adId`, this.audioDescriptionsController.deleteUserADAudios);
-    this.router.post(`${this.path}/publish-audio-description`, this.audioDescriptionsController.publishAudioDescription);
-    this.router.post(`${this.path}/unpublish-audio-description`, this.audioDescriptionsController.unpublishAudioDescription);
+    this.router.delete(`${this.path}/delete-user-ad-audios/:youtubeVideoId&:adId`, authMiddleware, this.audioDescriptionsController.deleteUserADAudios);
+    this.router.post(`${this.path}/publish-audio-description`, authMiddleware, this.audioDescriptionsController.publishAudioDescription);
+    this.router.post(`${this.path}/unpublish-audio-description`, authMiddleware, this.audioDescriptionsController.unpublishAudioDescription);
     this.router.get(`${this.path}/get-audio-description/:audioDescriptionId`, this.audioDescriptionsController.getAudioDescription);
-    this.router.get(`${this.path}/get-my-descriptions`, this.audioDescriptionsController.getMyDescriptions);
-    this.router.get(`${this.path}/get-my-draft-descriptions`, this.audioDescriptionsController.getMyDraftDescriptions);
-    this.router.get(`${this.path}/get-All-AI-descriptions`, this.audioDescriptionsController.getAllAIDescriptions);
+    this.router.get(`${this.path}/get-my-descriptions`, authMiddleware, this.audioDescriptionsController.getMyDescriptions);
+    this.router.get(`${this.path}/get-my-draft-descriptions`, authMiddleware, this.audioDescriptionsController.getMyDraftDescriptions);
+    this.router.get(`${this.path}/get-All-AI-descriptions`, authMiddleware, this.audioDescriptionsController.getAllAIDescriptions);
   }
 }
 

--- a/src/routes/notes.route.ts
+++ b/src/routes/notes.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import NotesController from '../controllers/notes.controller';
 import { Routes } from '../interfaces/routes.interface';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class NotesRoute implements Routes {
   public path = '/notes';

--- a/src/routes/notes.route.ts
+++ b/src/routes/notes.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import NotesController from '../controllers/notes.controller';
 import { Routes } from '../interfaces/routes.interface';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class NotesRoute implements Routes {
   public path = '/notes';
@@ -12,7 +13,7 @@ class NotesRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.post(`${this.path}/post-note`, this.notesController.postNoteByAdId);
+    this.router.post(`${this.path}/post-note`, authMiddleware, this.notesController.postNoteByAdId);
   }
 }
 

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import UsersController from '../controllers/users.controller';
 import { Routes } from '../interfaces/routes.interface';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class UsersRoute implements Routes {
   public path = '/users';

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -31,6 +31,7 @@ class UsersRoute implements Routes {
     this.router.get(`${this.path}/get-Visited-Videos-History`, this.usersController.getVisitedVideosHistory);
     this.router.post(`${this.path}/pipeline-failure`, this.usersController.handlePipelineFailure);
     this.router.post(`${this.path}/request-ai-descriptions-with-lana`, this.usersController.requestAiDescriptionsWithLana);
+    this.router.post(`${this.path}/updateoptin`, this.usersController.updateOptIn);
 
     this.router.get(`${this.path}/:userId`, this.usersController.getUserById);
   }

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import UsersController from '../controllers/users.controller';
 import { Routes } from '../interfaces/routes.interface';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class UsersRoute implements Routes {
   public path = '/users';
@@ -12,27 +13,27 @@ class UsersRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/get-all-users`, this.usersController.getUsers);
-    this.router.get(`${this.path}/user-email`, this.usersController.getUserByEmail);
-    this.router.post(`${this.path}/add-new-user`, this.usersController.createUser);
-    this.router.post(`${this.path}/create-new-user-ad`, this.usersController.createNewUserAudioDescription);
-    this.router.post(`${this.path}/create-collaborative-ad`, this.usersController.createCollaborativeDescription);
-    this.router.post(`${this.path}/calculate-contributions`, this.usersController.calculateContributions);
+    this.router.get(`${this.path}/get-all-users`, authMiddleware, this.usersController.getUsers);
+    this.router.get(`${this.path}/user-email`, authMiddleware, this.usersController.getUserByEmail);
+    this.router.post(`${this.path}/add-new-user`, authMiddleware, this.usersController.createUser);
+    this.router.post(`${this.path}/create-new-user-ad`, authMiddleware, this.usersController.createNewUserAudioDescription);
+    this.router.post(`${this.path}/create-collaborative-ad`, authMiddleware, this.usersController.createCollaborativeDescription);
+    this.router.post(`${this.path}/calculate-contributions`, authMiddleware, this.usersController.calculateContributions);
     this.router.post(`${this.path}/create-user`, this.usersController.createNewUser);
-    this.router.post(`${this.path}/request-ai-descriptions-with-gpu`, this.usersController.requestAiDescriptionsWithGpu);
+    this.router.post(`${this.path}/request-ai-descriptions-with-gpu`, authMiddleware, this.usersController.requestAiDescriptionsWithGpu);
     this.router.get(`${this.path}/ai-service-status`, this.usersController.getAiServiceStatus);
-    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, this.usersController.processAllClipsInDBController);
-    this.router.post(`${this.path}/generate-audio-desc-gpu`, this.usersController.generateAudioDescGpu);
-    this.router.post(`${this.path}/generate-ai-descriptions`, this.usersController.generateAiDescriptions);
-    this.router.post(`${this.path}/increase-Request-Count`, this.usersController.increaseRequestCount);
-    this.router.post(`${this.path}/ai-description-status`, this.usersController.aiDescriptionStatus);
-    this.router.get(`${this.path}/get-user-Ai-DescriptionRequests`, this.usersController.getUserAiDescriptionRequests);
-    this.router.post(`${this.path}/save-Visited-Videos-History`, this.usersController.saveVisitedVideosHistory);
-    this.router.get(`${this.path}/get-Visited-Videos-History`, this.usersController.getVisitedVideosHistory);
+    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, authMiddleware, this.usersController.processAllClipsInDBController);
+    this.router.post(`${this.path}/generate-audio-desc-gpu`, authMiddleware, this.usersController.generateAudioDescGpu);
+    this.router.post(`${this.path}/generate-ai-descriptions`, authMiddleware, this.usersController.generateAiDescriptions);
+    this.router.post(`${this.path}/increase-Request-Count`, authMiddleware, this.usersController.increaseRequestCount);
+    this.router.post(`${this.path}/ai-description-status`, authMiddleware, this.usersController.aiDescriptionStatus);
+    this.router.get(`${this.path}/get-user-Ai-DescriptionRequests`, authMiddleware, this.usersController.getUserAiDescriptionRequests);
+    this.router.post(`${this.path}/save-Visited-Videos-History`, authMiddleware, this.usersController.saveVisitedVideosHistory);
+    this.router.get(`${this.path}/get-Visited-Videos-History`, authMiddleware, this.usersController.getVisitedVideosHistory);
     this.router.post(`${this.path}/pipeline-failure`, this.usersController.handlePipelineFailure);
-    this.router.post(`${this.path}/request-ai-descriptions-with-lana`, this.usersController.requestAiDescriptionsWithLana);
+    this.router.post(`${this.path}/request-ai-descriptions-with-lana`, authMiddleware, this.usersController.requestAiDescriptionsWithLana);
 
-    this.router.get(`${this.path}/:userId`, this.usersController.getUserById);
+    this.router.get(`${this.path}/:userId`, authMiddleware, this.usersController.getUserById);
   }
 }
 

--- a/src/routes/videos.route.ts
+++ b/src/routes/videos.route.ts
@@ -1,8 +1,7 @@
 import { Router } from 'express';
 import VideosController from '../controllers/videos.controller';
 import { Routes } from '../interfaces/routes.interface';
-// import validationMiddleware from '../middlewares/validation.middleware';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class VideosRoute implements Routes {
   public path = '/videos';

--- a/src/routes/videos.route.ts
+++ b/src/routes/videos.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import VideosController from '../controllers/videos.controller';
 import { Routes } from '../interfaces/routes.interface';
 // import validationMiddleware from '../middlewares/validation.middleware';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class VideosRoute implements Routes {
   public path = '/videos';
@@ -15,8 +16,8 @@ class VideosRoute implements Routes {
   private initializeRoutes() {
     this.router.get(`${this.path}/home-videos`, this.videosController.getHomePageVideos);
     this.router.get(`${this.path}/get-by-youtubeVideo/:youtubeId`, this.videosController.getVideobyYoutubeId);
-    this.router.delete(`${this.path}/delete-video/:youtubeId/:userId`, this.videosController.deleteVideoForUser);
-    this.router.get(`${this.path}/user/:userId`, this.videosController.getVideosForUserId);
+    this.router.delete(`${this.path}/delete-video/:youtubeId/:userId`, authMiddleware, this.videosController.deleteVideoForUser);
+    this.router.get(`${this.path}/user/:userId`, authMiddleware, this.videosController.getVideosForUserId);
     this.router.get(`${this.path}/getyoutubedatafromcache`, this.videosController.getYoutubeDataFromCache);
     this.router.get(`${this.path}/search`, this.videosController.searchVideos);
     this.router.get(`${this.path}/:videoId`, this.videosController.getVideoById);

--- a/src/routes/wishlist.route.ts
+++ b/src/routes/wishlist.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import WishListController from '../controllers/wishlist.controller';
 import { Routes } from '../interfaces/routes.interface';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class WishListRoute implements Routes {
   public path = '/wishlist';

--- a/src/routes/wishlist.route.ts
+++ b/src/routes/wishlist.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import WishListController from '../controllers/wishlist.controller';
 import { Routes } from '../interfaces/routes.interface';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class WishListRoute implements Routes {
   public path = '/wishlist';
@@ -12,12 +13,12 @@ class WishListRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.post(`${this.path}/add-one-wishlist-item`, this.wishListController.addOneWishlistItem);
+    this.router.post(`${this.path}/add-one-wishlist-item`, authMiddleware, this.wishListController.addOneWishlistItem);
     this.router.post(`${this.path}/get-all-wishlist`, this.wishListController.getAllWishlist);
-    this.router.get(`${this.path}/get-user-wishlist`, this.wishListController.getUserWishlist);
+    this.router.get(`${this.path}/get-user-wishlist`, authMiddleware, this.wishListController.getUserWishlist);
     this.router.get(`${this.path}/get-top-wishlist`, this.wishListController.getTopWishList);
     this.router.get(`${this.path}/top`, this.wishListController.getTopWishListItems);
-    this.router.delete(`${this.path}/removeone`, this.wishListController.removeOne);
+    this.router.delete(`${this.path}/removeone`, authMiddleware, this.wishListController.removeOne);
   }
 }
 

--- a/src/routes/youtube-proxy.route.ts
+++ b/src/routes/youtube-proxy.route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { Routes } from '../interfaces/routes.interface';
 import YouTubeProxyController from '../controllers/youtube-proxy.controller';
+import authMiddleware from '../middlewares/auth.middleware';
 
 class YouTubeProxyRoute implements Routes {
   public path = '/youtube-proxy';
@@ -13,9 +14,9 @@ class YouTubeProxyRoute implements Routes {
 
   private initializeRoutes() {
     this.router.get(`${this.path}/videos`, this.youtubeProxyController.getVideos);
-    this.router.delete(`${this.path}/cache`, this.youtubeProxyController.invalidateCache);
-    this.router.get(`${this.path}/quota`, this.youtubeProxyController.getQuotaUsage);
-    this.router.delete(`${this.path}/clear-cache`, this.youtubeProxyController.clearCache);
+    this.router.delete(`${this.path}/cache`, authMiddleware, this.youtubeProxyController.invalidateCache);
+    this.router.get(`${this.path}/quota`, authMiddleware, this.youtubeProxyController.getQuotaUsage);
+    this.router.delete(`${this.path}/clear-cache`, authMiddleware, this.youtubeProxyController.clearCache);
   }
 }
 

--- a/src/routes/youtube-proxy.route.ts
+++ b/src/routes/youtube-proxy.route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { Routes } from '../interfaces/routes.interface';
 import YouTubeProxyController from '../controllers/youtube-proxy.controller';
-import authMiddleware from '../middlewares/auth.middleware';
+import authMiddleware from '../middlewares/auth.middleware'; // xiao: session guard for protected routes
 
 class YouTubeProxyRoute implements Routes {
   public path = '/youtube-proxy';

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -76,6 +76,32 @@ class UserService {
     }
   }
 
+  public async updateOptIn(userId: string, choices: boolean[]): Promise<IUser> {
+    if (isEmpty(userId)) throw new HttpException(400, 'UserId is empty');
+    if (!Array.isArray(choices)) throw new HttpException(400, 'choices must be an array');
+
+    // opt_in is the overall flag (true if any option selected); the two boolean
+    // fields persist each checkbox individually. choices[0] = wishlist published,
+    // choices[1] = automated AI feedback.
+    const optedIn = choices.some(Boolean);
+
+    const updatedUser = await MongoUsersModel.findByIdAndUpdate(
+      userId,
+      {
+        $set: {
+          opt_in: optedIn,
+          opt_in_wishlist_published: !!choices[0],
+          opt_in_ai_feedback: !!choices[1],
+          policy_review: true,
+          updated_at: nowUtc(),
+        },
+      },
+      { new: true },
+    );
+    if (!updatedUser) throw new HttpException(404, "User doesn't exist");
+    return updatedUser;
+  }
+
   public async createUser(userData: CreateUserDto): Promise<IUser | UsersAttributes> {
     if (isEmpty(userData)) throw new HttpException(400, 'userData is empty');
 


### PR DESCRIPTION
## Summary

Promotes two features merged to dev in July:

### #116 — Unified auth middleware (Xiao)
- New `src/middlewares/auth.middleware.ts`: rejects requests without a passport session (`req.user`) by throwing `AuthenticationError`, which `error.middleware.ts` maps to HTTP 401.
- Applied to ~35 protected endpoints across 8 route files (audio clips, audio descriptions, users, videos, wishlist, notes, ratings, youtube-proxy).
- Intentionally left public: AI pipeline callbacks (`newaidescription`, `aidescription-failure`, `pipeline-failure`, `ai-service-status`), login flow (`create-user`), and public reads (home videos, search, top wishlist, `get-audio-description`, `get-playback-type`).

### #117 — Opt-in save button backend (Hedy)
- New `POST /users/updateoptin` endpoint (session-guarded on dev via #116 conflict resolution).
- Two new User fields `opt_in_wishlist_published` / `opt_in_ai_feedback` (optional, default `false` — additive, no migration needed).
- `opt_in` becomes the aggregate flag; `policy_review` set to `true` on save.

## Deploy notes

- Anonymous requests to newly guarded endpoints now return 401 instead of assorted errors/empty results — this is the signal the frontend 401 interceptor expects. Verified on dev since 2026-07-21.
- Backend-first deploy is safe for #117: the new endpoint is unused until the frontend save button ships.
- Reverse diff (`dev...main`) is empty — the June single-flight hotfix on main is content-identical to dev's copy, so no conflicts.