### PR TITLE
feat: browser extension support — wishlist check endpoint + IDOR fixes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -79,16 +79,21 @@ class App {
   }
 
   private async initializeMiddlewares() {
-    if (NODE_ENV === 'development') {
-      this.app.use(
-        cors({
-          origin: ['http://localhost:3000', 'https://ydx-dev.youdescribe.org'],
-          credentials: true,
-          methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-          allowedHeaders: ['Content-Type', 'Authorization', 'Cookie', 'audiodescription'],
-        }),
-      );
-    }
+    const devOrigins = ['http://localhost:3000', 'https://ydx-dev.youdescribe.org'];
+    const prodOrigins = process.env.ORIGIN ? [process.env.ORIGIN] : ['https://youdescribe.org'];
+    const baseOrigins = NODE_ENV === 'development' ? devOrigins : prodOrigins;
+    // Set EXTENSION_ORIGIN in the server's .env once the extension ID is known from the manifest key.
+    const extensionOrigin = process.env.EXTENSION_ORIGIN || 'chrome-extension://REPLACE_WITH_EXTENSION_ID';
+    const allowedOrigins = [...baseOrigins, extensionOrigin];
+
+    this.app.use(
+      cors({
+        origin: allowedOrigins,
+        credentials: true,
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+        allowedHeaders: ['Content-Type', 'Authorization', 'Cookie', 'audiodescription'],
+      }),
+    );
     this.app.set('trust proxy', 1);
     this.app.use(compression());
     this.app.use(express.json());

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -470,6 +470,19 @@ class UsersController {
       next(error);
     }
   };
+
+  public getMe = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userData = req.user as unknown as IUser;
+      const user = await MongoUsersModel.findById(userData._id).select('_id name email picture admin_level user_type opt_in opt_in_wishlist_published');
+      if (!user) {
+        throw new Error('User not found');
+      }
+      res.status(200).json({ data: user });
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 export default UsersController;

--- a/src/controllers/wishlist.controller.ts
+++ b/src/controllers/wishlist.controller.ts
@@ -79,6 +79,20 @@ class WishListController {
     }
   };
 
+  public checkInWishlist = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userData = req.user as unknown as IUser;
+      if (!userData) {
+        throw new AuthenticationError('User not logged in');
+      }
+      const { youtubeId } = req.params;
+      const inWishlist = await this.wishlistService.checkInWishlist(String(userData._id), youtubeId);
+      res.status(200).json({ inWishlist });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   public removeOne = async (req: Request, res: Response) => {
     const userId: string = req.body.userId;
     const youTubeId: string = req.body.youTubeId;

--- a/src/controllers/wishlist.controller.ts
+++ b/src/controllers/wishlist.controller.ts
@@ -93,13 +93,19 @@ class WishListController {
     }
   };
 
-  public removeOne = async (req: Request, res: Response) => {
-    const userId: string = req.body.userId;
-    const youTubeId: string = req.body.youTubeId;
-
-    const result = await this.wishlistService.removeOne(userId, youTubeId);
-
-    return res.status(result.status).json({ message: result.message });
+  public removeOne = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userData = req.user as unknown as IUser;
+      if (!userData) {
+        throw new AuthenticationError('User not logged in');
+      }
+      const userId = String(userData._id);
+      const youTubeId: string = req.body.youTubeId;
+      const result = await this.wishlistService.removeOne(userId, youTubeId);
+      return res.status(result.status).json({ message: result.message });
+    } catch (error) {
+      next(error);
+    }
   };
 }
 

--- a/src/controllers/wishlist.controller.ts
+++ b/src/controllers/wishlist.controller.ts
@@ -39,12 +39,12 @@ class WishListController {
   public addOneWishlistItem = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { youTubeId } = req.body;
-      const { userId } = req.body;
+      const userData = req.user as unknown as IUser;
 
-      if (!userId) {
+      if (!userData) {
         throw new AuthenticationError('User not logged in');
       }
-      const user = await MongoUsersModel.findById(userId);
+      const user = await MongoUsersModel.findById(userData._id);
       if (!user) {
         throw new Error('User not found');
       }

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -34,6 +34,7 @@ class UsersRoute implements Routes {
     this.router.post(`${this.path}/request-ai-descriptions-with-lana`, authMiddleware, this.usersController.requestAiDescriptionsWithLana);
     this.router.post(`${this.path}/updateoptin`, authMiddleware, this.usersController.updateOptIn);
 
+    this.router.get(`${this.path}/me`, authMiddleware, this.usersController.getMe);
     this.router.get(`${this.path}/:userId`, authMiddleware, this.usersController.getUserById);
   }
 }

--- a/src/routes/wishlist.route.ts
+++ b/src/routes/wishlist.route.ts
@@ -13,6 +13,7 @@ class WishListRoute implements Routes {
   }
 
   private initializeRoutes() {
+    this.router.get(`${this.path}/check/:youtubeId`, authMiddleware, this.wishListController.checkInWishlist);
     this.router.post(`${this.path}/add-one-wishlist-item`, authMiddleware, this.wishListController.addOneWishlistItem);
     this.router.post(`${this.path}/get-all-wishlist`, this.wishListController.getAllWishlist);
     this.router.get(`${this.path}/get-user-wishlist`, authMiddleware, this.wishListController.getUserWishlist);

--- a/src/services/wishlist.service.ts
+++ b/src/services/wishlist.service.ts
@@ -637,7 +637,7 @@ class WishListService {
         return { status: 200, message: 'Video successfully removed from the wishlist.' };
       } else {
         // Decrease the vote count by 1 and update the wishlist item.
-        wishListItem.votes = Number(1) - 1;
+        wishListItem.votes = Number(wishListItem.votes) - 1;
         wishListItem.updated_at = Number(formattedDate(new Date()));
 
         await wishListItem.save();

--- a/src/services/wishlist.service.ts
+++ b/src/services/wishlist.service.ts
@@ -613,6 +613,11 @@ class WishListService {
     }
   }
 
+  public async checkInWishlist(userId: string, youtubeId: string): Promise<boolean> {
+    const vote = await MongoUserVotesModel.findOne({ user: userId, youtube_id: youtubeId }).lean();
+    return vote !== null;
+  }
+
   public async removeOne(userId: string, youTubeId: string) {
     try {
       const wishListItem = await MongoWishListModel.findOne({ youtube_id: youTubeId }).exec();


### PR DESCRIPTION
## Summary
- Adds browser extension CORS support via `EXTENSION_ORIGIN` env var (`chrome-extension://bofocaongbohcikmadfhjbmclbplfbnf`)
- Adds `GET /api/wishlist/check/:youtubeId` endpoint so the extension can check if a video is already wishlisted
- Fixes IDOR and vote-decrement bugs in `wishlist removeOne`

## Test plan
- [ ] Load the YouDescribeX-extension as an unpacked Chrome extension (Developer mode → Load unpacked)
- [ ] Confirm the extension can hit `POST /api/wishlist` to add a video
- [ ] Confirm `GET /api/wishlist/check/:youtubeId` returns correct `{ wishlisted: true/false }`
- [ ] Confirm removing a wishlist item no longer allows IDOR (only owner can remove)
- [ ] Confirm vote count doesn't go negative on double-remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)