### PR TITLE
hotfix: make processAllClipsInDB public again (AI TTS pipeline broken by #116 auth)

### DIFF
--- a/src/routes/audioClips.route.ts
+++ b/src/routes/audioClips.route.ts
@@ -14,7 +14,7 @@ class AudioClipsRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/processAllClipsInDB/:adId`, authMiddleware, this.audioClipController.processAllClipsInDB);
+    this.router.get(`${this.path}/processAllClipsInDB/:adId`, this.audioClipController.processAllClipsInDB);
     this.router.put(`${this.path}/update-clip-title/:clipId`, authMiddleware, this.audioClipController.updateAudioClipTitle);
     this.router.put(`${this.path}/update-clip-playback-type/:clipId`, authMiddleware, this.audioClipController.updateAudioClipPlaybackType);
     this.router.put(`${this.path}/update-clip-start-time/:clipId`, authMiddleware, this.audioClipController.updateAudioClipStartTime);

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -22,7 +22,7 @@ class UsersRoute implements Routes {
     this.router.post(`${this.path}/create-user`, this.usersController.createNewUser);
     this.router.post(`${this.path}/request-ai-descriptions-with-gpu`, authMiddleware, this.usersController.requestAiDescriptionsWithGpu);
     this.router.get(`${this.path}/ai-service-status`, this.usersController.getAiServiceStatus);
-    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, authMiddleware, this.usersController.processAllClipsInDBController);
+    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, this.usersController.processAllClipsInDBController);
     this.router.post(`${this.path}/generate-audio-desc-gpu`, authMiddleware, this.usersController.generateAudioDescGpu);
     this.router.post(`${this.path}/generate-ai-descriptions`, authMiddleware, this.usersController.generateAiDescriptions);
     this.router.post(`${this.path}/increase-Request-Count`, authMiddleware, this.usersController.increaseRequestCount);


### PR DESCRIPTION
## Problem (prod-critical regression)

The AI pipeline (`AI-generated-AD/server.py`) calls, server-to-server with **no session cookie**:
```
GET /api/audio-clips/processAllClipsInDB/<adId>
```
right after `newaidescription`, to generate the TTS audio for each clip and write `clip_audio_path` into Mongo.

PR #116 (unified auth middleware, promoted to main via #118 on 2026-07-28) added `authMiddleware` to this route. The cookieless AI call now returns **401 Authentication required**, so the TTS step never runs. Result: **every AI-generated AD created since #118 deployed has no audio** — the clips exist as text only, `clip_audio_path` is never saved (audio files land in storage, Mongo has no reference). Symptom: AD timeline / progress bar doesn't render on playback.

Prod log confirming:
```
[GET] /api/audio-clips/processAllClipsInDB/6a6a4b26c82b446c66de370f >> StatusCode:: 401, Message:: Authentication required
```

## Fix

Remove `authMiddleware` from the two `processAllClipsInDB` routes (`audioClips.route.ts`, `users.route.ts`), restoring them to public — matching the other AI-pipeline endpoints (`newaidescription`, `aidescription-failure`) which #116 correctly left public. The frontend does not call `processAllClipsInDB` (only server.py does), so this has no frontend impact and no effect on the other ~34 routes #116 guards.

## Notes

- Minimal, targeted fix — keeps #116's auth on all other routes and #117's opt-in endpoint intact (a full #118 revert would also drop `/users/updateoptin`, breaking the now-live opt-in save button).
- Existing broken ADs won't self-heal; they need TTS re-triggered (re-run processAllClipsInDB) to backfill audio.
- The same fix needs to land on `dev` too (separate PR) so the next dev→main promotion doesn't re-introduce the guard.
- Longer term, server-to-server AI calls should use a shared secret / internal auth rather than being fully public.