### PR TITLE
fix: make processAllClipsInDB public again (keep dev consistent with main hotfix #121)

### DIFF
--- a/src/routes/audioClips.route.ts
+++ b/src/routes/audioClips.route.ts
@@ -14,7 +14,7 @@ class AudioClipsRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/processAllClipsInDB/:adId`, authMiddleware, this.audioClipController.processAllClipsInDB);
+    this.router.get(`${this.path}/processAllClipsInDB/:adId`, this.audioClipController.processAllClipsInDB);
     this.router.put(`${this.path}/update-clip-title/:clipId`, authMiddleware, this.audioClipController.updateAudioClipTitle);
     this.router.put(`${this.path}/update-clip-playback-type/:clipId`, authMiddleware, this.audioClipController.updateAudioClipPlaybackType);
     this.router.put(`${this.path}/update-clip-start-time/:clipId`, authMiddleware, this.audioClipController.updateAudioClipStartTime);

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -22,7 +22,7 @@ class UsersRoute implements Routes {
     this.router.post(`${this.path}/create-user`, this.usersController.createNewUser);
     this.router.post(`${this.path}/request-ai-descriptions-with-gpu`, authMiddleware, this.usersController.requestAiDescriptionsWithGpu);
     this.router.get(`${this.path}/ai-service-status`, this.usersController.getAiServiceStatus);
-    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, authMiddleware, this.usersController.processAllClipsInDBController);
+    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, this.usersController.processAllClipsInDBController);
     this.router.post(`${this.path}/generate-audio-desc-gpu`, authMiddleware, this.usersController.generateAudioDescGpu);
     this.router.post(`${this.path}/generate-ai-descriptions`, authMiddleware, this.usersController.generateAiDescriptions);
     this.router.post(`${this.path}/increase-Request-Count`, authMiddleware, this.usersController.increaseRequestCount);


### PR DESCRIPTION
Companion to the main hotfix #121.

The AI pipeline calls `GET /api/audio-clips/processAllClipsInDB/:adId` server-to-server with no session cookie to generate TTS audio after creating an AD. #116's `authMiddleware` on this route makes that call 401 → TTS never runs → new AI ADs have no audio (`clip_audio_path` never written).

This applies the same fix to `dev` (remove `authMiddleware` from both `processAllClipsInDB` routes) so the guard isn't re-introduced on the next dev→main promotion. Frontend does not call this route; other #116-guarded routes are unaffected.