### PR TITLE
ci: fix cleanup stage failing on in-use image (false pipeline failure)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,6 @@ cleanup:
   stage: cleanup
   script:
     - echo "Cleaning up old images..."
-    - docker images --format "{{.ID}} {{.Repository}}" | grep "${DOCKER_REGISTRY}/${CI_PROJECT_NAME}" | sort -k2 | awk 'NR>1 {print $1}' | xargs -r docker rmi
     - docker container prune -f
     - docker image prune -af
   tags:


### PR DESCRIPTION
## Problem

Every deploy pipeline shows **Failed** even when build + deploy succeed, because the `cleanup` stage errors:
```
$ docker images ... | awk 'NR>1 {print $1}' | xargs -r docker rmi
Error response from daemon: conflict: unable to delete <id> (cannot be forced) - image is being used by running container <id>
ERROR: Job failed: exit status 1
```
The `docker rmi` line deletes a hand-computed list of this repo's images (`awk 'NR>1'`), which can include the image used by the **currently running container**. `docker rmi` hard-errors on an in-use image, so the job exits 1 and the pipeline is marked Failed — misleading, since the actual deploy already happened in the previous stage.

## Fix

Remove that `docker rmi` line. The next line — `docker image prune -af` — already removes all unused images and **safely skips in-use ones without erroring**, so disk cleanup still happens without the false failure. This removes the broken command rather than suppressing its error (no `|| true`).

## Result
- Pipelines no longer show false Failed on successful deploys.
- Old images still get pruned (`docker image prune -af` + `docker container prune -f`).