### PR TITLE
Promote dev to main: CI cleanup-stage fix + reconcile processAllClips hotfix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,6 @@ cleanup:
   stage: cleanup
   script:
     - echo "Cleaning up old images..."
-    - docker images --format "{{.ID}} {{.Repository}}" | grep "${DOCKER_REGISTRY}/${CI_PROJECT_NAME}" | sort -k2 | awk 'NR>1 {print $1}' | xargs -r docker rmi
     - docker container prune -f
     - docker image prune -af
   tags:

--- a/src/routes/audioClips.route.ts
+++ b/src/routes/audioClips.route.ts
@@ -14,7 +14,7 @@ class AudioClipsRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(`${this.path}/processAllClipsInDB/:adId`, authMiddleware, this.audioClipController.processAllClipsInDB);
+    this.router.get(`${this.path}/processAllClipsInDB/:adId`, this.audioClipController.processAllClipsInDB);
     this.router.put(`${this.path}/update-clip-title/:clipId`, authMiddleware, this.audioClipController.updateAudioClipTitle);
     this.router.put(`${this.path}/update-clip-playback-type/:clipId`, authMiddleware, this.audioClipController.updateAudioClipPlaybackType);
     this.router.put(`${this.path}/update-clip-start-time/:clipId`, authMiddleware, this.audioClipController.updateAudioClipStartTime);

--- a/src/routes/users.route.ts
+++ b/src/routes/users.route.ts
@@ -22,7 +22,7 @@ class UsersRoute implements Routes {
     this.router.post(`${this.path}/create-user`, this.usersController.createNewUser);
     this.router.post(`${this.path}/request-ai-descriptions-with-gpu`, authMiddleware, this.usersController.requestAiDescriptionsWithGpu);
     this.router.get(`${this.path}/ai-service-status`, this.usersController.getAiServiceStatus);
-    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, authMiddleware, this.usersController.processAllClipsInDBController);
+    this.router.get(`${this.path}/processAllClipsInDB/:ad_id`, this.usersController.processAllClipsInDBController);
     this.router.post(`${this.path}/generate-audio-desc-gpu`, authMiddleware, this.usersController.generateAudioDescGpu);
     this.router.post(`${this.path}/generate-ai-descriptions`, authMiddleware, this.usersController.generateAiDescriptions);
     this.router.post(`${this.path}/increase-Request-Count`, authMiddleware, this.usersController.increaseRequestCount);


### PR DESCRIPTION
Promotes the current `dev` to `main` (prod).

## What this actually changes on prod
- **`.gitlab-ci.yml`** — removes the broken `docker rmi` line from the `cleanup` stage (#123), so pipelines stop showing a false **Failed** when cleanup hits an in-use image. `docker image prune -af` still handles disk cleanup safely.

## Already on prod (no net change here)
- `processAllClipsInDB` made public again (unblocks the AI TTS pipeline) shipped to prod earlier as hotfix **#121**; dev got the same via **#122**. Both branches are now identical on those route files, so this promotion introduces no route change (verified by trial merge: clean, no conflict, route files show no net diff).

## Verification
- Trial merge dev→main: clean, no conflicts; the only file main gains is `.gitlab-ci.yml` (1 line removed).