### PR TITLE
Hedy/save button

### DIFF
--- a/src/services/audioDescriptions.service.ts
+++ b/src/services/audioDescriptions.service.ts
@@ -12,6 +12,7 @@ import {
   MongoVideosModel,
   MongoAICaptionRequestModel,
   MongoWishListModel,
+  MongoUserVotesModel,
 } from '../models/mongodb/init-models.mongo';
 import {
   Audio_DescriptionsAttributes,
@@ -26,6 +27,7 @@ import { getYouTubeVideoStatus, isEmpty, nowUtc } from '../utils/util';
 import { isVideoAvailable } from '../utils/videos.util';
 import cacheService from '../utils/cacheService';
 import GpuUtilsService from './gpu_utils.service';
+import sendEmail from '../utils/emailService';
 
 const fs = require('fs');
 
@@ -404,6 +406,8 @@ class AudioDescriptionsService {
 
       await MongoWishListModel.updateOne({ youtube_id: youtube_id, status: 'queued' }, { $set: { status: 'fulfilled' } });
 
+      await this.notifyWishlistSubscribers(youtube_id, videoIdStatus.title);
+
       logger.info(`[COLLAB] Audio description ${audioDescriptionId} published successfully`);
 
       await cacheService.invalidateByPrefix('home_videos');
@@ -418,6 +422,44 @@ class AudioDescriptionsService {
       throw error;
     }
   };
+
+  private async notifyWishlistSubscribers(youtube_id: string, videoTitle: string): Promise<void> {
+    try {
+      const voters = await MongoUserVotesModel.find({ youtube_id });
+      if (!voters.length) return;
+
+      const subscribers = await MongoUsersModel.find({
+        _id: { $in: voters.map(voter => voter.user) },
+        opt_in_wishlist_published: true,
+      });
+
+      for (const subscriber of subscribers) {
+        if (!subscriber.email) continue;
+        await sendEmail(
+          subscriber.email,
+          `Your wishlisted video now has an audio description!`,
+          this.getWishlistPublishedEmailBody(subscriber.name, videoTitle, youtube_id),
+        );
+      }
+    } catch (error: any) {
+      logger.error(`[COLLAB] Error notifying wishlist subscribers for video ${youtube_id}: ${error.message}`);
+    }
+  }
+
+  private getWishlistPublishedEmailBody(userName: string, videoTitle: string, youtube_id: string) {
+    return `
+      Dear ${userName},
+
+      Good news! A video on your wishlist, "${videoTitle}", now has an audio description published.
+
+      Watch it here: https://www.youtube.com/watch?v=${youtube_id}
+
+      Thank you for being a valued member of the YouDescribe community.
+
+      Best regards,
+      The YouDescribe Team
+  `;
+  }
 
   public unpublishAudioDescription = async (audioDescriptionId: string, youtube_id: string, user_id: string): Promise<string> => {
     try {

--- a/src/services/audioDescriptions.service.ts
+++ b/src/services/audioDescriptions.service.ts
@@ -406,7 +406,7 @@ class AudioDescriptionsService {
 
       await MongoWishListModel.updateOne({ youtube_id: youtube_id, status: 'queued' }, { $set: { status: 'fulfilled' } });
 
-      await this.notifyWishlistSubscribers(youtube_id, videoIdStatus.title);
+      await this.notifyWishlistSubscribers(youtube_id, videoIdStatus.title, audioDescriptionId);
 
       logger.info(`[COLLAB] Audio description ${audioDescriptionId} published successfully`);
 
@@ -423,7 +423,7 @@ class AudioDescriptionsService {
     }
   };
 
-  private async notifyWishlistSubscribers(youtube_id: string, videoTitle: string): Promise<void> {
+  private async notifyWishlistSubscribers(youtube_id: string, videoTitle: string, audioDescriptionId: string): Promise<void> {
     try {
       const voters = await MongoUserVotesModel.find({ youtube_id });
       if (!voters.length) return;
@@ -438,7 +438,7 @@ class AudioDescriptionsService {
         await sendEmail(
           subscriber.email,
           `Your wishlisted video now has an audio description!`,
-          this.getWishlistPublishedEmailBody(subscriber.name, videoTitle, youtube_id),
+          this.getWishlistPublishedEmailBody(subscriber.name, videoTitle, youtube_id, audioDescriptionId),
         );
       }
     } catch (error: any) {
@@ -446,13 +446,15 @@ class AudioDescriptionsService {
     }
   }
 
-  private getWishlistPublishedEmailBody(userName: string, videoTitle: string, youtube_id: string) {
+  private getWishlistPublishedEmailBody(userName: string, videoTitle: string, youtube_id: string, audioDescriptionId: string) {
+    const ydx_app_host = process.env.FRONTEND_URL || 'http://localhost:3000';
+    const previewURL = `${ydx_app_host}/video/${youtube_id}?ad=${audioDescriptionId}`;
     return `
       Dear ${userName},
 
       Good news! A video on your wishlist, "${videoTitle}", now has an audio description published.
 
-      Watch it here: https://www.youtube.com/watch?v=${youtube_id}
+      Watch it here: ${previewURL}
 
       Thank you for being a valued member of the YouDescribe community.
 

--- a/src/services/audioDescriptionsRating.service.ts
+++ b/src/services/audioDescriptionsRating.service.ts
@@ -1,7 +1,9 @@
-import { MongoAudio_Descriptions_Model, MongoAudioDescriptionRatingModel } from '../models/mongodb/init-models.mongo';
+import { MongoAudio_Descriptions_Model, MongoAudioDescriptionRatingModel, MongoUsersModel, MongoVideosModel } from '../models/mongodb/init-models.mongo';
 import { IAudioDescriptionRating } from '../models/mongodb/AudioDescriptionRating.mongo';
 import { nowUtc } from '../utils/util';
 import { Types } from 'mongoose';
+import sendEmail from '../utils/emailService';
+import { logger } from '../utils/logger';
 
 class AudioDescriptionRatingService {
   public async getUserRating(userId: string, audioDescriptionId: string): Promise<number | null> {
@@ -51,6 +53,8 @@ class AudioDescriptionRatingService {
         user: new Types.ObjectId(userId),
       });
 
+      let result: IAudioDescriptionRating;
+
       if (existingRating) {
         const updatedRating = await MongoAudioDescriptionRatingModel.findOneAndUpdate(
           { _id: existingRating._id },
@@ -67,7 +71,7 @@ class AudioDescriptionRatingService {
         }
 
         await this.updateOverallRating(audioDescriptionId, existingRating.rating, rating);
-        return updatedRating;
+        result = updatedRating;
       } else {
         const newRating = new MongoAudioDescriptionRatingModel({
           user: new Types.ObjectId(userId),
@@ -80,12 +84,52 @@ class AudioDescriptionRatingService {
 
         const createdRating = await newRating.save();
         await this.updateOverallRating(audioDescriptionId, 0, rating);
-        return createdRating;
+        result = createdRating;
       }
+
+      await this.notifyOwnerOfFeedback(userId, audioDescriptionId, rating, feedback);
+      return result;
     } catch (error) {
       console.error(`Error adding/updating rating for user ${userId} on audio description ${audioDescriptionId}:`, error);
       throw error;
     }
+  }
+
+  private async notifyOwnerOfFeedback(raterId: string, audioDescriptionId: string, rating: number, feedback: string[]): Promise<void> {
+    try {
+      const audioDescription = await MongoAudio_Descriptions_Model.findById(audioDescriptionId);
+      if (!audioDescription || audioDescription.user.toString() === raterId) return;
+
+      const owner = await MongoUsersModel.findOne({ _id: audioDescription.user, opt_in_ai_feedback: true });
+      if (!owner || !owner.email) return;
+
+      const video = await MongoVideosModel.findById(audioDescription.video);
+      const videoTitle = video ? video.title : 'your video';
+
+      await sendEmail(
+        owner.email,
+        `You've received feedback on your audio description`,
+        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, feedback),
+      );
+    } catch (error: any) {
+      logger.error(`Error notifying owner of feedback on audio description ${audioDescriptionId}: ${error.message}`);
+    }
+  }
+
+  private getFeedbackNotificationEmailBody(userName: string, videoTitle: string, rating: number, feedback: string[]) {
+    return `
+      Dear ${userName},
+
+      Someone has left feedback on your audio description for "${videoTitle}".
+
+      Rating: ${rating} / 5
+      ${feedback.length ? `Feedback: ${feedback.join(', ')}` : ''}
+
+      Thank you for contributing to the YouDescribe community.
+
+      Best regards,
+      The YouDescribe Team
+  `;
   }
 }
 

--- a/src/services/audioDescriptionsRating.service.ts
+++ b/src/services/audioDescriptionsRating.service.ts
@@ -109,14 +109,23 @@ class AudioDescriptionRatingService {
       await sendEmail(
         owner.email,
         `You've received feedback on your audio description`,
-        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, feedback),
+        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, feedback, video?.youtube_id, audioDescriptionId),
       );
     } catch (error: any) {
       logger.error(`Error notifying owner of feedback on audio description ${audioDescriptionId}: ${error.message}`);
     }
   }
 
-  private getFeedbackNotificationEmailBody(userName: string, videoTitle: string, rating: number, feedback: string[]) {
+  private getFeedbackNotificationEmailBody(
+    userName: string,
+    videoTitle: string,
+    rating: number,
+    feedback: string[],
+    youtube_id: string | undefined,
+    audioDescriptionId: string,
+  ) {
+    const ydx_app_host = process.env.FRONTEND_URL || 'http://localhost:3000';
+    const previewURL = youtube_id ? `${ydx_app_host}/video/${youtube_id}?ad=${audioDescriptionId}` : undefined;
     return `
       Dear ${userName},
 
@@ -124,6 +133,7 @@ class AudioDescriptionRatingService {
 
       Rating: ${rating} / 5
       ${feedback.length ? `Feedback: ${feedback.join(', ')}` : ''}
+      ${previewURL ? `Check out the video and its rating here: ${previewURL}` : ''}
 
       Thank you for contributing to the YouDescribe community.
 


### PR DESCRIPTION
handleSave POSTs the choices to /users/updateoptin.

Backend triggers:

- Wishlist published → [audioDescriptions.service.ts:349-464]: publishAudioDescription() marks the wishlist entry fulfilled (line 407) then calls notifyWishlistSubscribers() (line 409), which finds voters with opt_in_wishlist_published: true and calls sendEmail() per subscriber.

- Feedback (Rate) on published video → [audioDescriptionsRating.service.ts:90-144]: addOrUpdateRating() calls notifyOwnerOfFeedback(), which looks up the AD owner (skips self-feedback), checks opt_in_ai_feedback: true, and calls sendEmail().

- Both use the shared sendEmail(email, subject, content) in emailService.ts (Nodemailer/Gmail).