### PR TITLE
Hedy/video rating change

### DIFF
--- a/src/controllers/audioDescriptionRating.controller.ts
+++ b/src/controllers/audioDescriptionRating.controller.ts
@@ -13,9 +13,18 @@ class AudioDescriptionRatingController {
       const enjoymentRating = req.body.enjoymentRating;
       const comment = req.body.comment;
 
-      const newRating = await this.audioDescriptionRatingService.addRating(userId, audioDescriptionId, rating, feedback, enjoymentRating, comment);
+      const { rating: newRating, overallRating } = await this.audioDescriptionRatingService.addRating(
+        userId,
+        audioDescriptionId,
+        rating,
+        feedback,
+        enjoymentRating,
+        comment,
+      );
 
-      res.status(200).json({ result: newRating });
+      // `overallRating` lets the client show the description's new average
+      // without recomputing it, which is what used to drift on re-ratings.
+      res.status(200).json({ result: newRating, overallRating });
     } catch (error) {
       next(error);
     }

--- a/src/controllers/audioDescriptionRating.controller.ts
+++ b/src/controllers/audioDescriptionRating.controller.ts
@@ -10,8 +10,10 @@ class AudioDescriptionRatingController {
       const audioDescriptionId = req.params.audioDescriptionId;
       const rating = req.body.rating;
       const feedback = req.body.feedback || [];
+      const enjoymentRating = req.body.enjoymentRating;
+      const comment = req.body.comment;
 
-      const newRating = await this.audioDescriptionRatingService.addRating(userId, audioDescriptionId, rating, feedback);
+      const newRating = await this.audioDescriptionRatingService.addRating(userId, audioDescriptionId, rating, feedback, enjoymentRating, comment);
 
       res.status(200).json({ result: newRating });
     } catch (error) {

--- a/src/models/mongodb/AudioDescriptionRating.mongo.ts
+++ b/src/models/mongodb/AudioDescriptionRating.mongo.ts
@@ -5,6 +5,8 @@ interface IAudioDescriptionRating extends Document {
   audio_description: mongoose.Types.ObjectId;
   user: mongoose.Types.ObjectId;
   rating: number;
+  enjoyment_rating?: number;
+  comment?: string;
   feedback: Array<string>;
   created_at: number;
   updated_at: number;
@@ -25,6 +27,15 @@ const AudioDescriptionRatingSchema = new Schema<IAudioDescriptionRating>(
     rating: {
       type: Number,
       required: false,
+    },
+    enjoyment_rating: {
+      type: Number,
+      required: false,
+    },
+    comment: {
+      type: String,
+      required: false,
+      trim: true,
     },
     feedback: [
       {

--- a/src/services/audioDescriptionsRating.service.ts
+++ b/src/services/audioDescriptionsRating.service.ts
@@ -5,15 +5,29 @@ import { Types } from 'mongoose';
 import sendEmail from '../utils/emailService';
 import { logger } from '../utils/logger';
 
+export interface IUserRating {
+  rating: number | null;
+  enjoymentRating: number | null;
+  comment: string;
+}
+
 class AudioDescriptionRatingService {
-  public async getUserRating(userId: string, audioDescriptionId: string): Promise<number | null> {
+  public async getUserRating(userId: string, audioDescriptionId: string): Promise<IUserRating | null> {
     try {
       const rating = await MongoAudioDescriptionRatingModel.findOne({
         audio_description: new Types.ObjectId(audioDescriptionId),
         user: new Types.ObjectId(userId),
       });
 
-      return rating ? rating.rating : null;
+      if (!rating) {
+        return null;
+      }
+
+      return {
+        rating: rating.rating ?? null,
+        enjoymentRating: rating.enjoyment_rating ?? null,
+        comment: rating.comment ?? '',
+      };
     } catch (error) {
       console.error(`Error fetching user rating for user ${userId} on audio description ${audioDescriptionId}:`, error);
       throw error;
@@ -46,7 +60,14 @@ class AudioDescriptionRatingService {
     }
   }
 
-  public async addRating(userId: string, audioDescriptionId: string, rating: number, feedback: string[]): Promise<IAudioDescriptionRating> {
+  public async addRating(
+    userId: string,
+    audioDescriptionId: string,
+    rating: number,
+    feedback: string[],
+    enjoymentRating?: number,
+    comment?: string,
+  ): Promise<IAudioDescriptionRating> {
     try {
       const existingRating = await MongoAudioDescriptionRatingModel.findOne({
         audio_description: new Types.ObjectId(audioDescriptionId),
@@ -56,15 +77,19 @@ class AudioDescriptionRatingService {
       let result: IAudioDescriptionRating;
 
       if (existingRating) {
-        const updatedRating = await MongoAudioDescriptionRatingModel.findOneAndUpdate(
-          { _id: existingRating._id },
-          {
-            rating: rating,
-            feedback: feedback,
-            updated_at: nowUtc(),
-          },
-          { new: true },
-        );
+        const updateFields: Record<string, unknown> = {
+          rating: rating,
+          feedback: feedback,
+          updated_at: nowUtc(),
+        };
+        if (enjoymentRating !== undefined) {
+          updateFields.enjoyment_rating = enjoymentRating;
+        }
+        if (comment !== undefined) {
+          updateFields.comment = comment;
+        }
+
+        const updatedRating = await MongoAudioDescriptionRatingModel.findOneAndUpdate({ _id: existingRating._id }, updateFields, { new: true });
 
         if (!updatedRating) {
           throw new Error('Failed to update rating');
@@ -77,6 +102,8 @@ class AudioDescriptionRatingService {
           user: new Types.ObjectId(userId),
           audio_description: new Types.ObjectId(audioDescriptionId),
           rating: rating,
+          enjoyment_rating: enjoymentRating,
+          comment: comment,
           feedback: feedback,
           created_at: nowUtc(),
           updated_at: nowUtc(),

--- a/src/services/audioDescriptionsRating.service.ts
+++ b/src/services/audioDescriptionsRating.service.ts
@@ -11,6 +11,51 @@ export interface IUserRating {
   comment: string;
 }
 
+/** The description's rating aggregate after a vote, returned so the client can display it verbatim. */
+export interface IOverallRating {
+  overall_rating_votes_sum: number;
+  overall_rating_votes_counter: number;
+  overall_rating_votes_average: number;
+}
+
+export interface IAddRatingResult {
+  rating: IAudioDescriptionRating;
+  overallRating: IOverallRating | null;
+}
+
+/**
+ * Lowest score on each dimension that gets feedback emailed to the description
+ * owner. Lower ratings are still stored and still count towards the overall
+ * average — only the notification to the describer is withheld.
+ */
+export const OWNER_NOTIFICATION_MIN_RATING = 3;
+
+/**
+ * Both dimensions have to clear the bar independently, so feedback that was
+ * positive on one axis but poor on the other is not passed on.
+ *
+ * `enjoymentRating` is optional on the payload; when a client does not send one
+ * there is no second score to compare, so the comprehension rating decides.
+ */
+export const shouldNotifyOwnerOfRating = (rating: number, enjoymentRating?: number | null): boolean => {
+  if (rating < OWNER_NOTIFICATION_MIN_RATING) return false;
+  if (enjoymentRating === undefined || enjoymentRating === null) return true;
+  return enjoymentRating >= OWNER_NOTIFICATION_MIN_RATING;
+};
+
+/**
+ * The single star score a rating contributes: the mean of the comprehension and
+ * enjoyment answers, so the star display reflects both questions equally.
+ *
+ * Can be a half value (a 5 and a 4 average to 4.5); the stored average is kept
+ * unrounded and the UI rounds it for display. A rating with no enjoyment answer
+ * contributes its comprehension score alone.
+ */
+export const combinedRatingScore = (rating: number, enjoymentRating?: number | null): number => {
+  if (enjoymentRating === undefined || enjoymentRating === null) return rating;
+  return (rating + enjoymentRating) / 2;
+};
+
 class AudioDescriptionRatingService {
   public async getUserRating(userId: string, audioDescriptionId: string): Promise<IUserRating | null> {
     try {
@@ -34,26 +79,39 @@ class AudioDescriptionRatingService {
     }
   }
 
-  private async updateOverallRating(audioDescriptionId: string, previousRating: number, newRating: number) {
+  /**
+   * `previousScore`/`newScore` are combined comprehension+enjoyment scores (see
+   * `combinedRatingScore`), not raw comprehension ratings. A `previousScore` of
+   * 0 means this user had not rated before, so the vote counter goes up.
+   */
+  private async updateOverallRating(audioDescriptionId: string, previousScore: number, newScore: number): Promise<IOverallRating | null> {
     try {
       const audioDescription = await MongoAudio_Descriptions_Model.findById(audioDescriptionId);
 
       if (!audioDescription) {
         console.error(`Audio description not found for id: ${audioDescriptionId}`);
-        return;
+        return null;
       }
 
       const updatedData = {
-        overall_rating_votes_sum: (audioDescription.overall_rating_votes_sum || 0) - previousRating + newRating,
+        overall_rating_votes_sum: (audioDescription.overall_rating_votes_sum || 0) - previousScore + newScore,
         overall_rating_votes_counter:
-          previousRating === 0 ? (audioDescription.overall_rating_votes_counter || 0) + 1 : audioDescription.overall_rating_votes_counter,
+          previousScore === 0 ? (audioDescription.overall_rating_votes_counter || 0) + 1 : audioDescription.overall_rating_votes_counter,
         overall_rating_votes_average: 0,
         updated_at: nowUtc(),
       };
 
-      updatedData.overall_rating_votes_average = Math.floor(updatedData.overall_rating_votes_sum / (updatedData.overall_rating_votes_counter || 1));
+      // Kept unrounded: combined scores land on halves, and flooring 4.5 to 4
+      // would systematically under-report the star average. The UI rounds it.
+      updatedData.overall_rating_votes_average = updatedData.overall_rating_votes_sum / (updatedData.overall_rating_votes_counter || 1);
 
       await MongoAudio_Descriptions_Model.updateOne({ _id: audioDescriptionId }, updatedData);
+
+      return {
+        overall_rating_votes_sum: updatedData.overall_rating_votes_sum,
+        overall_rating_votes_counter: updatedData.overall_rating_votes_counter,
+        overall_rating_votes_average: updatedData.overall_rating_votes_average,
+      };
     } catch (error) {
       console.error(`Error updating overall rating for audio description ${audioDescriptionId}:`, error);
       throw error;
@@ -67,7 +125,7 @@ class AudioDescriptionRatingService {
     feedback: string[],
     enjoymentRating?: number,
     comment?: string,
-  ): Promise<IAudioDescriptionRating> {
+  ): Promise<IAddRatingResult> {
     try {
       const existingRating = await MongoAudioDescriptionRatingModel.findOne({
         audio_description: new Types.ObjectId(audioDescriptionId),
@@ -75,6 +133,7 @@ class AudioDescriptionRatingService {
       });
 
       let result: IAudioDescriptionRating;
+      let overallRating: IOverallRating | null;
 
       if (existingRating) {
         const updateFields: Record<string, unknown> = {
@@ -95,7 +154,13 @@ class AudioDescriptionRatingService {
           throw new Error('Failed to update rating');
         }
 
-        await this.updateOverallRating(audioDescriptionId, existingRating.rating, rating);
+        // Back out this user's previous combined score, not just its
+        // comprehension half, or the running sum drifts on every re-rating.
+        overallRating = await this.updateOverallRating(
+          audioDescriptionId,
+          combinedRatingScore(existingRating.rating, existingRating.enjoyment_rating),
+          combinedRatingScore(rating, enjoymentRating),
+        );
         result = updatedRating;
       } else {
         const newRating = new MongoAudioDescriptionRatingModel({
@@ -110,20 +175,28 @@ class AudioDescriptionRatingService {
         });
 
         const createdRating = await newRating.save();
-        await this.updateOverallRating(audioDescriptionId, 0, rating);
+        overallRating = await this.updateOverallRating(audioDescriptionId, 0, combinedRatingScore(rating, enjoymentRating));
         result = createdRating;
       }
 
-      await this.notifyOwnerOfFeedback(userId, audioDescriptionId, rating, enjoymentRating, comment);
-      return result;
+      await this.notifyOwnerOfFeedback(userId, audioDescriptionId, rating, enjoymentRating);
+      return { rating: result, overallRating };
     } catch (error) {
       console.error(`Error adding/updating rating for user ${userId} on audio description ${audioDescriptionId}:`, error);
       throw error;
     }
   }
 
-  private async notifyOwnerOfFeedback(raterId: string, audioDescriptionId: string, rating: number, enjoymentRating?: number, comment?: string): Promise<void> {
+  private async notifyOwnerOfFeedback(raterId: string, audioDescriptionId: string, rating: number, enjoymentRating?: number): Promise<void> {
     try {
+      // Checked before any lookups so a low rating costs nothing extra.
+      if (!shouldNotifyOwnerOfRating(rating, enjoymentRating)) {
+        logger.info(
+          `Skipping owner notification for audio description ${audioDescriptionId}: rating ${rating}, enjoyment ${enjoymentRating} below the ${OWNER_NOTIFICATION_MIN_RATING} threshold`,
+        );
+        return;
+      }
+
       const audioDescription = await MongoAudio_Descriptions_Model.findById(audioDescriptionId);
       if (!audioDescription || audioDescription.user.toString() === raterId) return;
 
@@ -136,7 +209,7 @@ class AudioDescriptionRatingService {
       await sendEmail(
         owner.email,
         `You've received feedback on your audio description`,
-        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, enjoymentRating, comment, video?.youtube_id, audioDescriptionId),
+        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, enjoymentRating, video?.youtube_id, audioDescriptionId),
       );
     } catch (error: any) {
       logger.error(`Error notifying owner of feedback on audio description ${audioDescriptionId}: ${error.message}`);
@@ -148,12 +221,13 @@ class AudioDescriptionRatingService {
     videoTitle: string,
     rating: number,
     enjoymentRating: number | undefined,
-    comment: string | undefined,
     youtube_id: string | undefined,
     audioDescriptionId: string,
   ) {
     const ydx_app_host = process.env.FRONTEND_URL || 'http://localhost:3000';
     const previewURL = youtube_id ? `${ydx_app_host}/video/${youtube_id}?ad=${audioDescriptionId}` : undefined;
+    // The rater's free-text comment is deliberately not included; it stays on
+    // the site rather than being pushed into the describer's inbox.
     return `
       Dear ${userName},
 
@@ -161,7 +235,6 @@ class AudioDescriptionRatingService {
 
       Rating: ${rating} / 5
       ${enjoymentRating !== undefined ? `Enjoyment: ${enjoymentRating} / 5` : ''}
-      ${comment ? `Comment: ${comment}` : ''}
       ${previewURL ? `Check out the video and its rating here: ${previewURL}` : ''}
 
       Thank you for contributing to the YouDescribe community.

--- a/src/services/audioDescriptionsRating.service.ts
+++ b/src/services/audioDescriptionsRating.service.ts
@@ -114,7 +114,7 @@ class AudioDescriptionRatingService {
         result = createdRating;
       }
 
-      await this.notifyOwnerOfFeedback(userId, audioDescriptionId, rating, feedback);
+      await this.notifyOwnerOfFeedback(userId, audioDescriptionId, rating, enjoymentRating, comment);
       return result;
     } catch (error) {
       console.error(`Error adding/updating rating for user ${userId} on audio description ${audioDescriptionId}:`, error);
@@ -122,7 +122,7 @@ class AudioDescriptionRatingService {
     }
   }
 
-  private async notifyOwnerOfFeedback(raterId: string, audioDescriptionId: string, rating: number, feedback: string[]): Promise<void> {
+  private async notifyOwnerOfFeedback(raterId: string, audioDescriptionId: string, rating: number, enjoymentRating?: number, comment?: string): Promise<void> {
     try {
       const audioDescription = await MongoAudio_Descriptions_Model.findById(audioDescriptionId);
       if (!audioDescription || audioDescription.user.toString() === raterId) return;
@@ -136,7 +136,7 @@ class AudioDescriptionRatingService {
       await sendEmail(
         owner.email,
         `You've received feedback on your audio description`,
-        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, feedback, video?.youtube_id, audioDescriptionId),
+        this.getFeedbackNotificationEmailBody(owner.name, videoTitle, rating, enjoymentRating, comment, video?.youtube_id, audioDescriptionId),
       );
     } catch (error: any) {
       logger.error(`Error notifying owner of feedback on audio description ${audioDescriptionId}: ${error.message}`);
@@ -147,7 +147,8 @@ class AudioDescriptionRatingService {
     userName: string,
     videoTitle: string,
     rating: number,
-    feedback: string[],
+    enjoymentRating: number | undefined,
+    comment: string | undefined,
     youtube_id: string | undefined,
     audioDescriptionId: string,
   ) {
@@ -159,7 +160,8 @@ class AudioDescriptionRatingService {
       Someone has left feedback on your audio description for "${videoTitle}".
 
       Rating: ${rating} / 5
-      ${feedback.length ? `Feedback: ${feedback.join(', ')}` : ''}
+      ${enjoymentRating !== undefined ? `Enjoyment: ${enjoymentRating} / 5` : ''}
+      ${comment ? `Comment: ${comment}` : ''}
       ${previewURL ? `Check out the video and its rating here: ${previewURL}` : ''}
 
       Thank you for contributing to the YouDescribe community.


### PR DESCRIPTION
## Summary
- Added persistence and API support for the two-part rating introduced in the frontend PR: 
an enjoyment score alongside the existing comprehension rating.
- Added a 3+ score threshold for the sending email function.
- Added average rating scores calculation for 5-star thumbnail (avg: comprehension+enjoyment)

Feedback notification email now reports the new fields instead of the
feedback string array:

  Rating: 4 / 5
  Enjoyment: 5 / 5          ← new

The feedback array field is left on the model and is still written by addRating — it's just no longer surfaced in the email, matching the frontend.

## How has this been tested?
Environment: local API on :4001 (NODE_ENV=development), shared dev Atlas cluster, app on :3000.

Manual testing:
- POST addOne with rating + enjoymentRating + comment → all three persisted on the rating document
- GET .../ratings/user/:id returns the new object shape; returns null when the user has never rated
- Rating email arrives with both Rating and Enjoyment lines populated (requires opt_in_ai_feedback on the AD owner, and rater ≠ owner); no comment is included in emails
- POST addOne with one score lower than 3, the email skips
- Screen reader testing and visual thumbnail of rating both show the average score with a decimal
- Legacy rating documents (no enjoyment_rating / comment) still load and display without error