### PR TITLE
feat(ai-drafts): add public AI drafts API

### DIFF
--- a/src/controllers/audioDescriptions.controller.ts
+++ b/src/controllers/audioDescriptions.controller.ts
@@ -185,14 +185,9 @@ class AudioDescripionsController {
 
   public getAllAIDescriptions = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const userData = req.user as unknown as IUser;
       const pageNumber = req.query.pageNumber;
 
-      if (!userData) {
-        throw new AuthenticationError('User not logged in');
-      }
-
-      const audioDescription = await this.audioDescriptionsService.getAllAIDescriptions(userData._id, <string>pageNumber);
+      const audioDescription = await this.audioDescriptionsService.getAllAIDescriptions(pageNumber as string);
 
       res.status(200).json(audioDescription);
     } catch (error) {

--- a/src/services/audioDescriptions.service.ts
+++ b/src/services/audioDescriptions.service.ts
@@ -691,78 +691,75 @@ class AudioDescriptionsService {
     }
   }
 
-  public async getAllAIDescriptions(user_id: string, pageNumber: string) {
-    if (!user_id) {
-      throw new HttpException(400, 'No data provided');
-    }
-
+  public async getAllAIDescriptions(pageNumber: string) {
     try {
-      const page = parseInt(pageNumber, 10) || 1;
-      const perPage = 5;
+      const page = Math.max(parseInt(pageNumber, 10) || 1, 1);
+      const perPage = 20;
       const skipCount = (page - 1) * perPage;
+
       const pipeline: any[] = [
-        { $match: { status: 'completed' } },
+        {
+          $match: {
+            status: 'draft',
+            admin_review: false,
+          },
+        },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'user',
+            foreignField: '_id',
+            as: 'userData',
+          },
+        },
+        { $unwind: '$userData' },
+        {
+          $match: {
+            'userData.user_type': 'AI',
+          },
+        },
         {
           $lookup: {
             from: 'videos',
-            localField: 'youtube_id',
-            foreignField: 'youtube_id',
-            as: 'video',
+            localField: 'video',
+            foreignField: '_id',
+            as: 'videoData',
           },
         },
-        { $unwind: '$video' },
-        {
-          $group: {
-            _id: '$_id',
-            status: { $first: '$status' },
-            video: { $first: '$video' },
-            requestCreatedAt: { $first: '$createdAt' },
-            requestUpdatedAt: { $first: '$updatedAt' },
-          },
-        },
-        {
-          $addFields: {
-            sortTier: {
-              $cond: [{ $ne: ['$requestUpdatedAt', null] }, 0, { $cond: [{ $ne: ['$requestCreatedAt', null] }, 1, 2] }],
-            },
-            sortDate: {
-              $ifNull: ['$requestUpdatedAt', '$requestCreatedAt'],
-            },
-          },
-        },
+        { $unwind: '$videoData' },
         {
           $project: {
-            _id: 1,
+            _id: 0,
+            audio_description_id: '$_id',
+            video_id: '$videoData._id',
+            youtube_id: '$videoData.youtube_id',
+            video_name: '$videoData.title',
+            video_length: '$videoData.duration',
+            createdAt: '$created_at',
+            updatedAt: '$updated_at',
             status: 1,
-            video_id: '$video._id',
-            youtube_id: '$video.youtube_id',
-            video_name: '$video.title',
-            video_length: '$video.duration',
-            createdAt: '$requestCreatedAt',
-            updatedAt: '$requestUpdatedAt',
-            sortTier: 1,
-            sortDate: 1,
+            admin_review: 1,
           },
         },
-        { $sort: { sortTier: 1, sortDate: -1, youtube_id: 1, _id: -1 } },
+        { $sort: { updatedAt: -1 } },
         {
           $facet: {
-            videos: [
-              { $skip: skipCount },
-              { $limit: perPage },
-              { $project: { sortTier: 0, sortDate: 0 } }, // hide internal sort fields
-            ],
+            videos: [{ $skip: skipCount }, { $limit: perPage }],
             totalCount: [{ $count: 'count' }],
           },
         },
         {
           $project: {
-            videos: '$videos',
-            total: { $arrayElemAt: ['$totalCount.count', 0] },
+            videos: 1,
+            total: {
+              $ifNull: [{ $arrayElemAt: ['$totalCount.count', 0] }, 0],
+            },
           },
         },
       ];
-      const result = await MongoAICaptionRequestModel.aggregate(pipeline).exec();
+
+      const result = await MongoAudio_Descriptions_Model.aggregate(pipeline).exec();
+
       return {
         result: result[0]?.videos || [],
         totalVideos: result[0]?.total || 0,

--- a/src/tests/audioDescriptions.controller.test.ts
+++ b/src/tests/audioDescriptions.controller.test.ts
@@ -1,0 +1,65 @@
+import { NextFunction, Request, Response } from 'express';
+import AudioDescriptionsController from '../controllers/audioDescriptions.controller';
+import AudioDescriptionsService from '../services/audioDescriptions.service';
+
+jest.mock('../services/audioDescriptions.service');
+
+jest.mock('../services/gpu_utils.service', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../utils/emailService', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('AudioDescriptionsController.getAllAIDescriptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows an unauthenticated request to retrieve AI drafts', async () => {
+    const controller = new AudioDescriptionsController();
+
+    const getAllAIDescriptionsMock = jest.spyOn(controller.audioDescriptionsService, 'getAllAIDescriptions').mockResolvedValue({
+      result: [
+        {
+          audio_description_id: 'audio-description-123',
+          youtube_id: 'youtube-123',
+        },
+      ],
+      totalVideos: 1,
+    });
+
+    const req = {
+      query: {
+        pageNumber: '2',
+      },
+    } as unknown as Request;
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+
+    const res = {
+      status,
+    } as unknown as Response;
+
+    const next = jest.fn() as NextFunction;
+
+    await controller.getAllAIDescriptions(req, res, next);
+
+    expect(getAllAIDescriptionsMock).toHaveBeenCalledWith('2');
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      result: [
+        {
+          audio_description_id: 'audio-description-123',
+          youtube_id: 'youtube-123',
+        },
+      ],
+      totalVideos: 1,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/audioDescriptions.service.test.ts
+++ b/src/tests/audioDescriptions.service.test.ts
@@ -1,0 +1,89 @@
+import AudioDescriptionsService from '../services/audioDescriptions.service';
+import { MongoAudio_Descriptions_Model } from '../models/mongodb/init-models.mongo';
+
+jest.mock('../services/gpu_utils.service', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../models/mongodb/init-models.mongo', () => ({
+  MongoAudio_Descriptions_Model: {
+    aggregate: jest.fn(),
+  },
+}));
+
+describe('AudioDescriptionsService.getAllAIDescriptions', () => {
+  const aggregateMock = MongoAudio_Descriptions_Model.aggregate as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns public AI drafts with their audio description IDs', async () => {
+    const execMock = jest.fn().mockResolvedValue([
+      {
+        videos: [
+          {
+            audio_description_id: 'audio-description-123',
+            youtube_id: 'youtube-123',
+            video_name: 'Test video',
+            status: 'draft',
+            admin_review: false,
+          },
+        ],
+        total: 1,
+      },
+    ]);
+
+    aggregateMock.mockReturnValue({
+      exec: execMock,
+    });
+
+    const service = new AudioDescriptionsService();
+    const result = await service.getAllAIDescriptions('1');
+
+    expect(result).toEqual({
+      result: [
+        {
+          audio_description_id: 'audio-description-123',
+          youtube_id: 'youtube-123',
+          video_name: 'Test video',
+          status: 'draft',
+          admin_review: false,
+        },
+      ],
+      totalVideos: 1,
+    });
+
+    expect(aggregateMock).toHaveBeenCalledTimes(1);
+
+    const pipeline = aggregateMock.mock.calls[0][0];
+
+    expect(pipeline).toEqual(
+      expect.arrayContaining([
+        {
+          $match: {
+            status: 'draft',
+            admin_review: false,
+          },
+        },
+        {
+          $match: {
+            'userData.user_type': 'AI',
+          },
+        },
+      ]),
+    );
+
+    expect(pipeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          $project: expect.objectContaining({
+            audio_description_id: '$_id',
+            youtube_id: '$videoData.youtube_id',
+          }),
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
# Summary
- allow unauthenticated users to view AI drafts
- return the corresponding `audio_description_id`
- filter for unreviewed AI-generated draft descriptions

# Testing
- build passed
- 2 targeted tests passed